### PR TITLE
Added $valid value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,9 @@ const validationGetters = {
       this.ruleKeys.some((rule) => !proxy[rule])
     )
   },
+  $valid() {
+    return !this.$invalid
+  },
   $dirty() {
     if (this.dirty) {
       return true

--- a/test/unit/specs/validation.spec.js
+++ b/test/unit/specs/validation.spec.js
@@ -514,6 +514,7 @@ describe('Validation plugin', () => {
             value: { isEven }
           }
         })
+        expect(vm.$v.value.$valid).to.be.true
         expect(vm.$v.value.$invalid).to.be.false
       })
       it('should have validator name value set to true', () => {
@@ -539,6 +540,7 @@ describe('Validation plugin', () => {
             value: { isEven }
           }
         })
+        expect(vm.$v.value.$valid).to.be.false
         expect(vm.$v.value.$invalid).to.be.true
       })
       it('should have validator name value set to false', () => {


### PR DESCRIPTION
I've added `$valid` getter as I sometimes want to use it and it's easier to read than `!$v.value.$invalid` (no need for double negation).

Let me know if this makes sense and if you want me to update docs etc.