### PR TITLE
Feature/errors getter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ const validationGetters = {
   },
   $anyError() {
     if (this.$error) return true
-    
+
     return this.nestedKeys.some((key) => this.refProxy(key).$anyError)
   },
   $pending() {

--- a/src/index.js
+++ b/src/index.js
@@ -95,6 +95,10 @@ const validationGetters = {
   $error() {
     return this.$dirty && !this.$pending && this.$invalid
   },
+  $errors() {
+    const proxy = this.proxy
+    return this.ruleKeys.filter((rule) => !proxy[rule])
+  },
   $anyError() {
     if (this.$error) return true
 


### PR DESCRIPTION
First referred as #419 **EDIT:** also #149 (a weird anagram-ish coincidence if you ask me) 

This will enable to have a `$errors : Array` which contains all the failing rules keys. It allows to use the keys with `vue-i18n` easily and iterate over errors if necessary.

I checked on the #149 thread and honestly all the solutions proposed are overkill for a feature which so many people asked for, regarding the code which is actually implied.

Some thoughts about that thread (if you wish to move back to #149 let me know) :

- About the "you should build it with custom components" : for CMS (which are mainly using forms), a lot - if not most - of them are using ui libraries such as Vuetify, Element, and so on (even sometimes custom ones). For most implementations, error fields are props that you pass along, and not template that you can build and insert. For such reason, most of the time, this solution don't work.

- About the "$errors name is confusing" point : I can hear it, tho it seems obvious enough that all the third party proposals are basically using it `${prefix}Errors` (`$errors`, `getValidationErrors`, `$allErrors`, ... you see my point). this library already uses `$error : Boolean`, why not `$errors : Array`. If it's written in the docs, what's so non obvious about it ?

About the recursivity : i understand the need, since you can also use vuelidate in the context of a form. Nevertheless, this feature aiming at targeting directly a field, it seems totally normal not to be recursive ; although i'm sure we could easily add the recursive path as a prefix to the key (`form.email.required`, for example)

About the sorting : sure it's needed. I know it's not "obvious" and "enforced", but everyone coding javascript understand that key order matters in an object. For such reason, even if it seems "not obvious enough" or "prone to error" on an ideologic level, i think it actually is enough for javascript developers to be happy with the feature.

Finally. This demand has been commented for few months (Jun 1st to Oct 27th) last year, and it's been 2 years already, and all i can see is "thinking about the APi". I totally understand and would be more than happy to help on that matter, but also would wish to have something - even temporary - delivered, as it seems blocking for a lot of project using this more than needed library.