### PR TITLE
Updated the `required` validator to strip whitespace of strings so …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ const validationGetters = {
   },
   $anyError() {
     if (this.$error) return true
-    
+
     return this.nestedKeys.some((key) => this.refProxy(key).$anyError)
   },
   $pending() {

--- a/src/validators/required.js
+++ b/src/validators/required.js
@@ -1,2 +1,7 @@
 import { withParams, req } from './common'
-export default withParams({ type: 'required' }, req)
+export default withParams({ type: 'required' }, (value) => {
+  if (typeof value === 'string') {
+    return req(value.trim())
+  }
+  return req(value)
+})

--- a/test/unit/specs/validators/integer.spec.js
+++ b/test/unit/specs/validators/integer.spec.js
@@ -40,11 +40,11 @@ describe('integer validator', () => {
   it('should not validate unicode', () => {
     expect(integer('🎉')).to.be.false
   })
-  
+
   it('should not validate minus sign', () => {
     expect(integer('-')).to.be.false
-})
-  
+  })
+
   it('should validate negative numbers', () => {
     expect(integer('-123')).to.be.true
   })

--- a/test/unit/specs/validators/required.spec.js
+++ b/test/unit/specs/validators/required.spec.js
@@ -38,7 +38,7 @@ describe('required validator', () => {
   })
 
   it('should validate string only with spaces', () => {
-    expect(required('  ')).to.be.true
+    expect(required('  ')).to.be.false
   })
 
   it('should validate english words', () => {


### PR DESCRIPTION
…that pure whitespace strings fail the validation.

- Fixed lint warnings