### PR TITLE
Update _examples.pug to clarify error visibility

### DIFF
--- a/docs/partials/examples/_examples.pug
+++ b/docs/partials/examples/_examples.pug
@@ -3,6 +3,9 @@
     p.typo__p
       | For each value you want to validate, you have to create a key inside <kbd>validations</kbd> options.
       | You can specify when input becomes dirty by using appropriate event on your input box.
+    p.typo__p
+      | Note that in this example, the red border, red text, and error message visibility are driven by the presence or absence of the <kbd>form-group--error</kbd> class on the surrounding <kbd>div</kbd>. 
+      | Any markup relating to validation errors will show on initial load unless using a method like this, or by using validations without v-model (next section).
     +example('ExampleBasic')
 
   +subsection('Without v-model')


### PR DESCRIPTION
The current documentation doesn't make it very clear that errors will show on initial load, and that the example given relies on custom CSS to hide error messages.