### PR TITLE
allow deep requiredIf string

### DIFF
--- a/src/validators/common.js
+++ b/src/validators/common.js
@@ -38,7 +38,7 @@ export const len = (value) => {
 export const ref = (reference, vm, parentVm) =>
   typeof reference === 'function'
     ? reference.call(vm, parentVm)
-    : reference.split('.').reduce((parent, prop) => parent[prop], parentVm);
+    : reference.split('.').reduce((parent, prop) => parent === void 0 ? void 0 : parent[prop], parentVm);
 
 // regex based validator template
 export const regex = (type, expr) =>

--- a/src/validators/common.js
+++ b/src/validators/common.js
@@ -38,7 +38,7 @@ export const len = (value) => {
 export const ref = (reference, vm, parentVm) =>
   typeof reference === 'function'
     ? reference.call(vm, parentVm)
-    : parentVm[reference]
+    : reference.split('.').reduce((parent, prop) => parent[prop], parentVm);
 
 // regex based validator template
 export const regex = (type, expr) =>

--- a/test/unit/specs/ref.spec.js
+++ b/test/unit/specs/ref.spec.js
@@ -1,0 +1,24 @@
+import { ref } from 'src/validators/common'
+const vm = { id: Symbol('vm') };
+const parentVm = { id: Symbol('parentVm'), vm };
+describe('ref (common helper)', () => {
+  it('should call function with given context & arguments if passed a function', () => {
+    // testFn cannot be an arrow function as the injected 'this' context is being tested
+    const testFn = function(...args) {
+      return [this].concat(args);
+    };
+    expect(ref(testFn, vm, parentVm)).to.have.ordered.members([vm, parentVm]);
+  });
+
+  it('should return property of parentVm if passed a string', () => {
+    expect(ref('id', vm, parentVm)).to.equal(parentVm.id);
+  })
+
+  it('should return a deep property of parentVm if passed a string containing \'.\'', () => {
+    expect(ref('vm.id', vm, parentVm)).to.equal(vm.id);
+  })
+
+  it('should return undefined if string containing \'.\' is a deep property not yet defined', () => {
+    expect(ref('vm.a.b', vm, parentVm)).to.equal(void 0);
+  })
+})

--- a/test/unit/specs/validators/requiredIf.spec.js
+++ b/test/unit/specs/validators/requiredIf.spec.js
@@ -19,4 +19,12 @@ describe('requiredIf validator', () => {
   it('should validate empty string when prop condition not met', () => {
     expect(requiredIf('prop')('', { prop: false })).to.be.true
   })
+
+  it('should not validate empty string when nested prop condition is met', () => {
+    expect(requiredIf('prop.foo')('', { prop: { foo: true } })).to.be.false
+  })
+
+  it('should validate empty string when nested prop condition not met', () => {
+    expect(requiredIf('prop.foo')('', { prop: { foo: false } })).to.be.true
+  })
 })


### PR DESCRIPTION
this line of code allows the requiredIf validator (and any validators using the ```ref``` helper) to use dot notation to describe deep properties ('foo.bar'). see the added tests.