### PR TITLE
Update Next docs

### DIFF
--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -15,7 +15,7 @@ This will install the entire mono-repo deps, not only the docs. **Yarn is requir
 After installing you can cd into the docs package and run:
 
 ```bash
-yarn dev
+yarn dev:docs
 ```
 
 This will open a local development version of the docs, powered by VuePress.

--- a/packages/docs/src/.vuepress/config.js
+++ b/packages/docs/src/.vuepress/config.js
@@ -14,8 +14,9 @@ module.exports = {
     logo: 'logo.png',
     sidebar: [
       '/',
-      'examples',
+      'guide',
       'advanced_usage',
+      'examples',
       'api',
       'validators',
       'custom_validators',

--- a/packages/docs/src/.vuepress/config.js
+++ b/packages/docs/src/.vuepress/config.js
@@ -15,6 +15,7 @@ module.exports = {
     sidebar: [
       '/',
       'examples',
+      'advanced_usage',
       'api',
       'validators',
       'custom_validators',

--- a/packages/docs/src/README.md
+++ b/packages/docs/src/README.md
@@ -1,58 +1,56 @@
 # Getting started
 
+**Vuelidate 2** is a simple, but powerful, lightweight model-based validation for Vue.js 3.
 
-Vuelidate 2 is a simple, but powerful, lightweight model-based validation for Vue.js.
+Vuelidate is considered _model-based_ because the validation rules are defined next to your data, and the validation tree structure matches the data model structure.
 
-It supports Vue 3
+_If you are looking for Vuelidate that supports Vue 2, use [Vuelidate 1](https://github.com/vuelidate/vuelidate/tree/v1)._
 
 ## Installation
 
-Package is installable via npm
+You can install via npm
 
 ```bash
-npm install vuelidate --save
+npm install @vuelidate/core @vuelidate/validators --save
 ```
 
-## Basic usage
+## Getting Started
 
-You can import the library and `use` as a Vue plugin to enable the functionality globally on all components containing validation configuration.
+You can import the library and use it as a Vue plugin to enable the functionality globally on all components containing validation configuration.
 
 ```js
 import Vue from 'vue'
-import Vuelidate from 'vuelidate'
-Vue.use(Vuelidate)
+import Vuelidate from '@vuelidate/core'
+
+const app = Vue.createApp(App)
+app.use(Vuelidate)
 ```
 
-Alternatively it is possible to import a mixin directly to components in which it will be used.
+Then in your component you can create a `validations` method.
 
-```vue
-<script>
-import { validationMixin } from 'vuelidate'
-
+```js
+import { required } from '@vuelidate/validators'
 export default {
-  mixins: [validationMixin],
-  validations: { ... }
+  data() {
+    return {
+      name: ''
+    }
+  },
+  validations() {
+    return {
+      name: { required }
+    }
+  }
 }
-</script>
 ```
 
-If you prefer using `require`, it can be used instead of `import` statements. This works especially great with destructuring syntax.
+You now have a `v$` object available in your component's `this` context, that you can check for validation statuses:
 
 ```js
-const { validationMixin, default: Vuelidate } = require('vuelidate')
-const { required, minLength } = require('vuelidate/lib/validators')
+{
+  $invalid: true,
+  $error: false,
+}
 ```
 
-The browser-ready bundle is also provided in the package.
-
-```html
-<script src="vuelidate/dist/vuelidate.min.js"></script>
-```
-```js
-// global
-Vue.use(window.vuelidate.default)
-
-// local mixin
-var validationMixin = window.vuelidate.validationMixin
-```
-Check out the [JSFiddle example](https://jsfiddle.net/Frizi/b5v4faqf/) which uses this setup.
+There, you are all set. Lets go to the [Examples](./examples.md) page, to see what you can do with Vuelidate.

--- a/packages/docs/src/README.md
+++ b/packages/docs/src/README.md
@@ -8,15 +8,19 @@ _If you are looking for Vuelidate that supports Vue 2, use [Vuelidate 1](https:/
 
 ## Installation
 
-You can install via npm
+Installing Vuelidate is straightforward, and can be done with your package manager of choice.
 
 ```bash
 npm install @vuelidate/core @vuelidate/validators --save
+
+// OR
+
+yarn add @vuelidate/core @vuelidate/validators
 ```
 
 ## Getting Started
 
-You can import the library and use it as a Vue plugin to enable the functionality globally on all components containing validation configuration.
+You can then import Vuelidate and use it as a Vue plugin to enable the functionality globally on all components containing validation configuration.
 
 ```js
 import Vue from 'vue'
@@ -26,7 +30,40 @@ const app = Vue.createApp(App)
 app.use(Vuelidate)
 ```
 
-Then in your component you can create a `validations` method and define your validation rules.
+Now that Vuelidate is registered as a global plugin, create a `validations` function inside your component and define your validation rules.
+
+First, import the validators that you want to use from `@vuelidate/validators`.
+
+```js
+import { required } from '@vuelidate/validators'
+```
+
+Next, add the `validations` function, it should return an object that matches the structure of your state. In this example, we have a field `name`, which is declared inside of the component's `data()`.
+
+Notice that in the `validations` function we declare the same structure, and the `name` property specifies the validators that we want to apply to it - in this case, a `required` validation.
+
+Below you can find a visual example of the relation between the component internal state in `data` and the `validations` object. Notice the structure matches exactly.
+
+```js
+data () {
+  return {
+    firstName: '',
+    lastName: '',
+    contact: {
+      email: ''
+    }
+  }
+},
+validations () {
+  return {
+    firstName: { required }, // Matches this.firstName
+    lastName: { required }, // Matches this.lastName
+    contact: {
+      email: { required, email } // Matches this.contact.email
+    }
+  }
+}
+```
 
 ```js
 import { required } from '@vuelidate/validators'
@@ -44,15 +81,34 @@ export default {
 }
 ```
 
-Now in your templates you can check for errors like this:
+Now that validations are set up, we can check inside our template for errors by looking at the `name` property inside of the `v$` Vuelidate object. It will hold all the information and state of our `name` state's validation.
+
+If _any_ error is present, the `$errors` array property inside of `$v.name` will contain an object that describes each error for us to loop through.
+
+Each object inside the `$errors` array will contain a few properties that allows us to dynamically build our error message.
+
+An example of our `name` property being in an error state due to it being required would be:
+
+```js
+{
+  "$property": "name",
+  "$validator": "required",
+  "$message": "The value is required",
+  [...]
+}
+```
+
+Now that we understand the basic content of the error objects, we can build our error messages in the template. This approach will dynamically cover any number of validators that were applied to our input.
 
 ```vue
-<div :class="{ error: v$.name.$error }">
+<div :class="{ error: v$.name.$errors.length }">
   <input v-model="name">
-  <div v-if="v$.name.$error">
-    <div v-if="v$.name.required">The Name field is required</div>
+  <div class="input-errors" v-for="(error, index) of v$.name.$errors">
+    <div class="error-msg">{{ error.$message }}</div>
   </div>
 </div>
 ```
 
-There, you are all set. Head over to the [Guide](./guide.md) page, to for a more detailed guide on how to use Vuelidate.
+That's it! Our validations are set and ready.
+
+Head over to the [Guide](./guide.md) page now for a more detailed guide on how to use Vuelidate.

--- a/packages/docs/src/README.md
+++ b/packages/docs/src/README.md
@@ -26,7 +26,7 @@ const app = Vue.createApp(App)
 app.use(Vuelidate)
 ```
 
-Then in your component you can create a `validations` method.
+Then in your component you can create a `validations` method and define your validation rules.
 
 ```js
 import { required } from '@vuelidate/validators'
@@ -44,13 +44,15 @@ export default {
 }
 ```
 
-You now have a `v$` object available in your component's `this` context, that you can check for validation statuses:
+Now in your templates you can check for errors like this:
 
-```js
-{
-  $invalid: true,
-  $error: false,
-}
+```vue
+<div :class="{ error: v$.name.$error }">
+  <input v-model="name">
+  <div v-if="v$.name.$error">
+    <div v-if="v$.name.required">The Name field is required</div>
+  </div>
+</div>
 ```
 
-There, you are all set. Lets go to the [Examples](./examples.md) page, to see what you can do with Vuelidate.
+There, you are all set. Head over to the [Guide](./guide.md) page, to for a more detailed guide on how to use Vuelidate.

--- a/packages/docs/src/advanced_usage.md
+++ b/packages/docs/src/advanced_usage.md
@@ -2,7 +2,7 @@
 
 ## Per component mixin
 
-Alternatively it is possible to import a mixin directly to components in which it will be used.
+Alternatively it is possible to apply all the Vuelidate functionality to dedicated components via a mixin.
 
 ```vue
 <script>
@@ -10,11 +10,16 @@ import { VuelidateMixin } from '@vuelidate/core'
 
 export default {
   mixins: [VuelidateMixin],
+  data(){ },
   validations() { }
 }
 </script>
 ```
 
+Everything else is the same.
+
 ## Composition API
+
+## Validating collections
 
 ## Validating nested forms

--- a/packages/docs/src/advanced_usage.md
+++ b/packages/docs/src/advanced_usage.md
@@ -1,0 +1,18 @@
+# Advanced usage
+
+## Per component mixin
+
+Alternatively it is possible to import a mixin directly to components in which it will be used.
+
+```vue
+<script>
+import { VuelidateMixin } from '@vuelidate/core'
+
+export default {
+  mixins: [VuelidateMixin],
+  validations() { }
+}
+</script>
+```
+
+## Composition API

--- a/packages/docs/src/advanced_usage.md
+++ b/packages/docs/src/advanced_usage.md
@@ -16,3 +16,5 @@ export default {
 ```
 
 ## Composition API
+
+## Validating nested forms

--- a/packages/docs/src/api.md
+++ b/packages/docs/src/api.md
@@ -5,7 +5,7 @@ There are two distinct structures present in _vuelidate_:
 * `validations` component option - the definition of your validation
 * `$v structure` - an object in your viewmodel that holds the validation state
 
-## $v values
+## Validation State Values
 
 `$v` model represents the current state of validation. It does so by defining a set of properties which hold the output of user defined validation functions, following the `validations` option structure. The presence of those special reserved keywords means that you cannot specify your own validators with that name.
 

--- a/packages/docs/src/examples.md
+++ b/packages/docs/src/examples.md
@@ -1,11 +1,5 @@
 # Examples
 
-## Basic form
-
-For each value you want to validate, you have to create a key inside `validations` options. You can specify when input becomes dirty by using appropriate event on your input box.
-
-> Example
-
 ## Without v-model
 
 In case you don't want to modify your model directly, you can still use separate `:input` and `@event` bindings. This is especially useful if you are using data from external source, like Vuex store or props. In that case you have to manually take care of setting the `$dirty` by calling `$touch()` method when appropriate.

--- a/packages/docs/src/guide.md
+++ b/packages/docs/src/guide.md
@@ -35,9 +35,10 @@ Validators can be as simple as functions returning a boolean, you are free to wr
 
 We have a our validation rules ready, now we need to check for errors.
 
-Vuelidate builds a validation state, that can be accessed via the `v$` property. It is a nested object that roughly follows your `validations` structure, but with some extra validity related properties. It is reactive, meaning it changes as you type.
+Vuelidate builds a validation state, that can be accessed via the `v$` property. It is a nested object that roughly follows your `validations` structure,
+but with some extra validity related properties. It is reactive, meaning it changes as you type.
 
-So for our form above, to check whether name is valid, we would do:
+So for our form above, to check whether name is valid, we would can see if the `name.$error` property is `true` or not:
 
 ```html
 <label>
@@ -46,36 +47,109 @@ So for our form above, to check whether name is valid, we would do:
 </label>
 ```
 
-The properties you will check against the most are:
+It is as simple as that. Using this approach, you can apply error classes, show messages or add attributes.
 
-```js
-const v$ = {
-    $errors: [],
-    $error: false,
-    $invalid: false,
-    $dirty: false,
-    $pending: false,
-    // ... and others
-    name: {
-      $error: false,
-      $invalid: false,
-      $dirty: false,
-      $pending: false,
-      // ... and others
-    }
-}
+The properties you will check against most often are:
+
 ```
-
-The validation state has properties for each validator, that hold a set of helpful properties that we can use to show warnings, add classes and more.
+  "$dirty": false,
+  "$error": false,
+  "$errors": [],
+  "$invalid": false,
+```
 
 This is just a subset of all the properties, but they are enough to get us started. To see all available properties, check the [Validation state API](./api.md#validation-state-values)
 
-- explain collective properties
-
 ### The dirty state
 
-- lazy by default
-- auto dirty
+Vuelidate tracks the `dirty` state of each field, which means it can tell you when a field has beep changed. This can come in handy to determine when to show error messages, or compare data.
+
+To change the `$dirty` state on a field, you can use the handy `$touch()` method, attached to an `input` event.
+
+```html
+<input v-model="name" @input="v$.name.$touch">
+```
+
+This will ensure that the field is "touched" every time you input something.
+
+#### Using the $model property
+
+If you want to make things a bit cleaner, you can use the `$model`, available for each field data property.
+This is a special property that points to your validator's bound model data, and calls `touch` when you augment that field's data.
+
+```html
+<input v-model="v$.name.$model">
+```
+
+#### Setting dirty state with $autoDirty
+
+It is quite common to forget to use `$model` or `$touch`. If you want to ensure dirty state is always tracked, you can use the `$autoDirty` settings property, when defining your validations:
+
+```js
+export default {
+  validations() {
+    return {
+      name: { required, $autoDirty: true },
+    }
+  }
+}
+```
+
+It will ensure the validator tracks it's bound data, and sets the dirty state accordingly.
+
+You can then change your field's `v-model` to:
+
+```html
+<input v-model="name">
+```
+
+#### Lazy validations by default
+
+Validation in Vuelidate 2 is by default lazy, meaning validators are only called, after a field is dirty, ie `touche()` is called.
+
+#### Resetting dirty state
+
+If you wish to reset a form's `$dirty` state, you can do so by using the appropriately named `$reset` method. For example when closing a modal, you dont want the validation to stay.
+
+```html
+<app-modal @closed="v$.$reset()">
+  <!-- some inputs  -->
+</app-modal>
+```
+
+### Collective properties
+
+The validation state has entries for each validator, that hold a set of helpful properties that we can use to show warnings, add classes and more.
+
+```json
+{
+  "$dirty": false,
+  "$error": false,
+  "$errors": [],
+  "$invalid": false,
+  // .. other properties
+  "name": {
+    "$dirty": false,
+    "required": {
+      "$message": "Value is required",
+      "$params": {},
+      "$pending": false,
+      "$invalid": false
+    },
+    "$invalid": false,
+    "$pending": false,
+    "$error": false,
+    "$errors": [],
+    // .. other properties
+  }
+}
+```
+
+As you can see, the `name` field has it's own `$dirty`, `$error` among other attributes, as well as an object for the `required` validator.
+
+The root properties like, `$dirty`, `$error` and `$invalid` are all collective computed properties, meaning their value changes depending on the nested children's state.
+
+**Example:** If a form has 10 fields and one of them has it's `$error: true`, then the root `$error` will also be `true`, giving allot of flexibility when trying to display error state.
 
 ### Displaying error messages
 

--- a/packages/docs/src/guide.md
+++ b/packages/docs/src/guide.md
@@ -199,6 +199,62 @@ The root properties like, `$dirty`, `$error` and `$invalid` are all collective c
 
 ### Displaying error messages
 
-### Submitting forms
+The validation state holds data like the invalid state of each validator of a property, along with extra properties, like an error message or extra parameters.
+
+The easiest way to display errors is to use the form's top level `$errors` property. It is an array of validation objects, that you can iterate over.
+
+```vue
+<p
+  v-for="(error, index) of $v.$errors"
+  :key="index"
+>
+  <strong>{{ error.$validator }}</strong>
+  <small> on property</small>
+  <strong>{{ error.$property }}</strong>
+  <small> says:</small>
+  <strong>{{ error.$message }}</strong>
+</p>
+```
+
+You can also check for errors on each form property:
+
+```vue
+<p
+  v-for="(error, index) of $v.name.$errors"
+  :key="index"
+>
+  <!-- Same as above -->
+</p>
+```
+
+### Validating forms before submitting
+
+To submit a form, you often need to validate it first. In most cases, you can just check for the `$error` status of the form. It is a good practice to `$touch` the form first, so all validators initiate.
+
+```js
+export default {
+  methods: {
+    submitForm() {
+      this.$v.$touch()
+      if(this.$v.$error) return
+      // do stuff
+    }
+  }
+}
+```
+
+This is good for the general case, but what if you have async validators? You can use the `$validate` method, which returns a promise. That promise resolves with a boolean,
+depending on what the validation status is.
+
+```js
+export default {
+  methods: {
+    async submitForm() {
+      if(! await this.$v.$validate()) return
+      // do stuff
+    }
+  }
+}
+```
 
 ## Validating collections

--- a/packages/docs/src/guide.md
+++ b/packages/docs/src/guide.md
@@ -1,10 +1,13 @@
 # Guide
 
 ## Basics
-As we mentioned before, validation rules are set inside an object, that is returned by the `validations` method. We will refer to those as just _validations_.
+As we mentioned in the [getting started quick guide](/#getting-started-2), validation rules are defined inside the object returned by the `validations` method. We will refer to those as just _validations_ from now on.
+
 You can access the component's instance and it's properties via `this` when writing more complicated validation rules.
 
+::: warning
 **Note:** Pre Vuelidate 2 `validations` was allowed to be an object as well as a function. This is still available, for backwards compatibility reasons, but is discouraged. Please migrate to a method instead.
+:::
 
 Each validation rule must have a corresponding property inside the `data` object.
 
@@ -29,16 +32,20 @@ export default {
 
 Vuelidate comes with a set of validators, that live inside the `@vuelidate/validations` package, which you must install separately. For a full list of available validators, check the [Validators](./validators.md) page.
 
-Validators can be as simple as functions returning a boolean, you are free to write your own or use third party validators. Read more about how to write your own validators on the [Custom Validators](./custom_validators.md) page.
+Validators are functions that return a boolean value after checking the validity of the state of a form.
+
+Vuelidate also supports writing your own custom validators, you can learn more about how to write your own validators on the [Custom Validators](./custom_validators.md) page.
 
 ### Checking for validation state
 
-We have a our validation rules ready, now we need to check for errors.
+Now that we have our validation rules set up, we can start checking for errors.
 
-Vuelidate builds a validation state, that can be accessed via the `v$` property. It is a nested object that roughly follows your `validations` structure,
-but with some extra validity related properties. It is reactive, meaning it changes as you type.
+Vuelidate builds a validation state, that can be accessed via the `v$` property. It is a nested object that follows your `validations` structure,
+but with some extra validity related properties.
 
-So for our form above, to check whether name is valid, we would can see if the `name.$error` property is `true` or not:
+`v$` is also reactive - meaning it changes as the user types.
+
+Building up on our form example above, to check whether name is valid we can now check to see if the `name.$error` property is `true` or `false`, and display an error for our users.
 
 ```html
 <label>
@@ -47,7 +54,7 @@ So for our form above, to check whether name is valid, we would can see if the `
 </label>
 ```
 
-It is as simple as that. Using this approach, you can apply error classes, show messages or add attributes.
+Using this approach, you can apply error classes, show messages or add attributes.
 
 The properties you will check against most often are:
 
@@ -62,9 +69,13 @@ This is just a subset of all the properties, but they are enough to get us start
 
 ### The dirty state
 
-Vuelidate tracks the `dirty` state of each field, which means it can tell you when a field has beep changed. This can come in handy to determine when to show error messages, or compare data.
+Vuelidate tracks the `dirty` state of each field.
 
-To change the `$dirty` state on a field, you can use the handy `$touch()` method, attached to an `input` event.
+A field is considered `dirty` after it has received some sort of interaction from the user, which means all fields begin with a `dirty` state of `false`. Once the user types into, or modifies the `value` of the input's model, the field's `$dirty` state becomes `true`.
+
+This can come in handy to determine when to show error messages, or compare data.
+
+If you ever need to programmatically change the  `$dirty` state on a field to `true` - as if the user of your form had manipulated it, you can use the handy `$touch()` method, attached to an `input` event.
 
 ```html
 <input v-model="name" @input="v$.name.$touch">
@@ -72,14 +83,49 @@ To change the `$dirty` state on a field, you can use the handy `$touch()` method
 
 This will ensure that the field is "touched" every time you input something.
 
+This same process can be achieved within your methods and watchers by directly calling the function in them.
+
+```js
+methods: {
+  makeDirty() {
+    this.$v.name.$touch()
+  }
+}
+```
+
 #### Using the $model property
 
-If you want to make things a bit cleaner, you can use the `$model`, available for each field data property.
-This is a special property that points to your validator's bound model data, and calls `touch` when you augment that field's data.
+A less verbose way to ensure that your validations are ran whenever your input's state changes is to directly bind your input's `v-model` declaration into the `$model` of that field's validation object.
+
+This is a special property that points to your validator's bound model data, and calls `touch` when you update or modify that field's data.
 
 ```html
-<input v-model="v$.name.$model">
+<template>
+  <input v-model="v$.name.$model">
+</template>
+
+<script>
+import { required } from '@vuelidate/validators'
+export default {
+  data() {
+    return {
+      name: ''
+    }
+  },
+  validations: {
+    name: { required }
+  }
+}
+</script>
 ```
+
+In the above example, we no longer need to call `$touch` manually every time the input is updated.
+
+Additionally, Vuelidate will take of updating the state of the component for you.
+
+In the above example, whenever the `input` element changes, `v$.name.$touch()` will be called, updating the state of the validation - and the `name` state will be updated.
+
+This binding is accomplished internally through a getter/setter that reads and updates the original state. When the setter is called, it also triggers `$touch()` for that property.
 
 #### Setting dirty state with $autoDirty
 

--- a/packages/docs/src/guide.md
+++ b/packages/docs/src/guide.md
@@ -1,0 +1,84 @@
+# Guide
+
+## Basics
+As we mentioned before, validation rules are set inside an object, that is returned by the `validations` method. We will refer to those as just _validations_.
+You can access the component's instance and it's properties via `this` when writing more complicated validation rules.
+
+**Note:** Pre Vuelidate 2 `validations` was allowed to be an object as well as a function. This is still available, for backwards compatibility reasons, but is discouraged. Please migrate to a method instead.
+
+Each validation rule must have a corresponding property inside the `data` object.
+
+```html
+<script>
+import { required } from '@vuelidate/validators'
+
+export default {
+  data() {
+    return {
+      name: ''
+    }
+  },
+  validations() {
+    return {
+      name: { required }
+    }
+  }
+}
+</script>
+```
+
+Vuelidate comes with a set of validators, that live inside the `@vuelidate/validations` package, which you must install separately. For a full list of available validators, check the [Validators](./validators.md) page.
+
+Validators can be as simple as functions returning a boolean, you are free to write your own or use third party validators. Read more about how to write your own validators on the [Custom Validators](./custom_validators.md) page.
+
+### Checking for validation state
+
+We have a our validation rules ready, now we need to check for errors.
+
+Vuelidate builds a validation state, that can be accessed via the `v$` property. It is a nested object that roughly follows your `validations` structure, but with some extra validity related properties. It is reactive, meaning it changes as you type.
+
+So for our form above, to check whether name is valid, we would do:
+
+```html
+<label>
+  <input v-model="name">
+  <div v-if="v$.name.$error">Name field has an error.</div>
+</label>
+```
+
+The properties you will check against the most are:
+
+```js
+const v$ = {
+    $errors: [],
+    $error: false,
+    $invalid: false,
+    $dirty: false,
+    $pending: false,
+    // ... and others
+    name: {
+      $error: false,
+      $invalid: false,
+      $dirty: false,
+      $pending: false,
+      // ... and others
+    }
+}
+```
+
+The validation state has properties for each validator, that hold a set of helpful properties that we can use to show warnings, add classes and more.
+
+This is just a subset of all the properties, but they are enough to get us started. To see all available properties, check the [Validation state API](./api.md#validation-state-values)
+
+- explain collective properties
+
+### The dirty state
+
+- lazy by default
+- auto dirty
+
+### Displaying error messages
+
+### Submitting forms
+
+## Validating collections

--- a/packages/docs/src/guide.md
+++ b/packages/docs/src/guide.md
@@ -40,17 +40,17 @@ Vuelidate also supports writing your own custom validators, you can learn more a
 
 Now that we have our validation rules set up, we can start checking for errors.
 
-Vuelidate builds a validation state, that can be accessed via the `v$` property. It is a nested object that follows your `validations` structure,
+Vuelidate builds a validation state, that can be accessed via the `$v` property. It is a nested object that follows your `validations` structure,
 but with some extra validity related properties.
 
-`v$` is also reactive - meaning it changes as the user types.
+`$v` is also reactive - meaning it changes as the user types.
 
 Building up on our form example above, to check whether name is valid we can now check to see if the `name.$error` property is `true` or `false`, and display an error for our users.
 
 ```html
 <label>
   <input v-model="name">
-  <div v-if="v$.name.$error">Name field has an error.</div>
+  <div v-if="$v.name.$error">Name field has an error.</div>
 </label>
 ```
 
@@ -78,7 +78,7 @@ This can come in handy to determine when to show error messages, or compare data
 If you ever need to programmatically change the  `$dirty` state on a field to `true` - as if the user of your form had manipulated it, you can use the handy `$touch()` method, attached to an `input` event.
 
 ```html
-<input v-model="name" @input="v$.name.$touch">
+<input v-model="name" @input="$v.name.$touch">
 ```
 
 This will ensure that the field is "touched" every time you input something.
@@ -101,7 +101,7 @@ This is a special property that points to your validator's bound model data, and
 
 ```html
 <template>
-  <input v-model="v$.name.$model">
+  <input v-model="$v.name.$model">
 </template>
 
 <script>
@@ -123,7 +123,7 @@ In the above example, we no longer need to call `$touch` manually every time the
 
 Additionally, Vuelidate will take of updating the state of the component for you.
 
-In the above example, whenever the `input` element changes, `v$.name.$touch()` will be called, updating the state of the validation - and the `name` state will be updated.
+In the above example, whenever the `input` element changes, `$v.name.$touch()` will be called, updating the state of the validation - and the `name` state will be updated.
 
 This binding is accomplished internally through a getter/setter that reads and updates the original state. When the setter is called, it also triggers `$touch()` for that property.
 
@@ -143,7 +143,7 @@ export default {
 
 It will ensure the validator tracks it's bound data, and sets the dirty state accordingly.
 
-You can then change your field's `v-model` to:
+You can then change your field's `v-model` expression to just the data property:
 
 ```html
 <input v-model="name">
@@ -151,14 +151,17 @@ You can then change your field's `v-model` to:
 
 #### Lazy validations by default
 
-Validation in Vuelidate 2 is by default lazy, meaning validators are only called, after a field is dirty, ie `touche()` is called.
+Validation in Vuelidate 2 is by default `lazy`, meaning validators are only called, after a field is dirty, so after `touch()` is called or by using `$model`.
+
+This saves extra invocations for async validators as well as makes the initial validation setup a bit more performant.
 
 #### Resetting dirty state
 
-If you wish to reset a form's `$dirty` state, you can do so by using the appropriately named `$reset` method. For example when closing a modal, you dont want the validation to stay.
+If you wish to reset a form's `$dirty` state, you can do so by using the appropriately named `$reset` method.
+For example when closing a create/edit modal, you dont want the validation state to persist.
 
 ```html
-<app-modal @closed="v$.$reset()">
+<app-modal @closed="$v.$reset()">
   <!-- some inputs  -->
 </app-modal>
 ```
@@ -199,7 +202,9 @@ The root properties like, `$dirty`, `$error` and `$invalid` are all collective c
 
 ### Displaying error messages
 
-The validation state holds data like the invalid state of each validator of a property, along with extra properties, like an error message or extra parameters.
+The validation state holds useful data, like the invalid state of each property validator, along with extra properties, like an error message or extra parameters.
+
+Error messages come out of the box with the bundled validators in `@vuelidate/validators` package. You can check how change those them over at the [Custom Validators page](./custom_validators.md)
 
 The easiest way to display errors is to use the form's top level `$errors` property. It is an array of validation objects, that you can iterate over.
 
@@ -256,5 +261,3 @@ export default {
   }
 }
 ```
-
-## Validating collections


### PR DESCRIPTION
## Description

This PR updates the Vuelidate Next docs, to a more guide oriented approach, where we teach the users how to use Vuelidate, compared to before, where we just threw some APIs and examples at them.

This should ensure an easier introduction, while still keeping the API and Examples pages, for more advanced users.

This is ofc a very very early draft, many things are yet to be done.

## Things to consider

One thing we need to figure out is examples. In Vuelidate 0.x they were real live components, that you could interact with, hosted with the docs files.

We cant really do this now, as Vuepress runs vue 2, and the code uses vue 3

**We can:** 
1. Migrate over to Vitepress (too early imho)
2. Wait it out for now.
3. Just add static example code
4. Use a plugin, like https://github.com/QingWei-Li/vuep but more maintained.