### PR TITLE
fix: chain of state refs

### DIFF
--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -1,5 +1,5 @@
 import { isFunction, isPromise, unwrap, unwrapObj } from './utils'
-import { computed, reactive, ref, watch, isRef } from 'vue'
+import { computed, reactive, ref, watch, isRef } from 'vue-demi'
 
 /**
  * @typedef NormalizedValidator

--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -1,5 +1,5 @@
 import { isFunction, isPromise, unwrap, unwrapObj } from './utils'
-import { computed, reactive, ref, watch, isRef } from 'vue-demi'
+import { computed, reactive, ref, watch, isRef } from 'vue'
 
 /**
  * @typedef NormalizedValidator
@@ -307,7 +307,7 @@ function collectNestedValidationResults (validations, state, key, path, resultsC
   return nestedValidationKeys.reduce((results, nestedKey) => {
     // if we have a key, use the nested state
     // else use top level state
-    const nestedState = key ? state[key] : state
+    const nestedState = key ? computed(() => unwrap(unwrap(state)[key])) : state
 
     // build validation results for nested state
     results[nestedKey] = setValidations({
@@ -445,6 +445,7 @@ export function setValidations ({
   resultsCache
 }) {
   const path = parentKey ? `${parentKey}.${key}` : key
+
   // Sort out the validation object into:
   // – rules = validators for current state tree fragment
   // — nestedValidators = nested state fragments keys that might contain more validators
@@ -476,22 +477,25 @@ export function setValidations ({
    */
 
   const $model = key ? computed({
-    get: () => unwrap(state[key]),
+    get: () => unwrap(unwrap(state)[key]),
     set: val => {
       $dirty.value = true
-      if (isRef(state[key])) {
-        state[key].value = val
+      const unwrappedState = unwrap(state)
+
+      if (isRef(unwrappedState[key])) {
+        unwrappedState[key].value = val
       } else {
-        state[key] = val
+        unwrappedState[key] = val
       }
     }
   }) : null
 
   if (config.$autoDirty) {
-    const watchTarget = isRef(state[key]) ? state[key] : computed(() => unwrap(state)[key])
-    watch(watchTarget, () => {
-      if (!$dirty.value) $touch()
-    })
+    watch(
+      () => unwrap(unwrap(state)[key]),
+      () => {
+        if (!$dirty.value) $touch()
+      })
   }
 
   function $validate () {

--- a/packages/vuelidate/test/unit/validations.fixture.js
+++ b/packages/vuelidate/test/unit/validations.fixture.js
@@ -25,6 +25,31 @@ export function nestedReactiveObjectValidation () {
   return { state, validations }
 }
 
+export function nestedRefObjectValidation () {
+  const state = ref({
+    level0: 0,
+    level1: {
+      child: 1,
+      level2: {
+        child: 2
+      }
+    }
+  })
+
+  const validations = {
+    level0: { isEven, $autoDirty: true },
+    level1: {
+      $autoDirty: true,
+      child: { isEven, $autoDirty: true },
+      level2: {
+        $autoDirty: true,
+        child: { isEven, $autoDirty: true }
+      }
+    }
+  }
+  return { state, validations }
+}
+
 export function computedValidationsObjectWithRefs () {
   const conditional = ref(0)
   const number = ref(0)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

**Description:**

~~1. Using the mixin, I found out that `validations` was passed to `setValidations` as a reference. It was problematic. Suppose I wrote:~~
```js
defineComponent({
  validations: {
    foo: {
      required
    }
  }
});
```
~~Vuelidate interpreted it without unwrapping it first, as if I had written:~~
```js
defineComponent({
  validations: {
    value: {
      foo: {
        required
      }
    }
  }
});
```

~~This patch unwraps `validations`.~~

This first part is already fixed by @shentao in 5725a38da12848fc699c719dafa06706107f0374

2. Refs of nested objects lose reactivity after the first level. Imagine I can only use a ref.
```js
defineComponent({
  setup (props) {
    // "props" is a shallow reactive object, so it means "foo" is not reactive
    // All I can do is to extract a reference.
    const {
      foo
    } = toRefs(props);

    const validation = useVuelidate({
      foo: {
        bar: {
          x: {
            required
          }
        }
      }
    }, { foo });

    return {
      validation
    };
  }
});
```

Vuelidate will lose reactivity after the `foo` level. To see why, let's take a look at how vuelidate transverses the state tree.
```
    const nestedState = key ? state[key] : state
```

This translates to a simple `state['foo']['bar']['x']`. It works well for reactive objects but not for references. Even if references were unwrapped, reactivity is lost.

To preserve reactivity, I thought about chaining references using `computed`. This way references are unwrapped inside computed functions and thus preserve reactivity.
```
    const nestedState = !key ? state : computed(() => unwrap(unwrap(state)[key]))
```

There are many `unwraps` but I believe they are necessary. In the first level, the key `foo` in the state `{ foo }` is a reference. But in subsequent levels, the state itself is a reference because it was generated from `computed()`. So we have to beware of references in both `state` and `state[key]`.

**Testing:**
Right now I'm unable to run tests. it goes on a never ending loop about missing individual babel plugins starting with `@babel/plugin-transform-runtime`.

This was only tested on a personal project I am migrating from Vue 2 to Vue 3. However I plan to 