### PR TITLE
fix(validators): fix `not`,`or`, `and` validators.

### DIFF
--- a/packages/validators/src/common.js
+++ b/packages/validators/src/common.js
@@ -1,6 +1,4 @@
-import withParams from './utils/withParams'
-import withMessage from './utils/withMessage'
-import { req, len, regex } from './raw/core'
-
-export { withParams, withMessage, req, len, regex }
+export { default as withParams } from './utils/withParams'
+export { default as withMessage } from './utils/withMessage'
+export { req, len, regex } from './raw/core'
 export { unwrap, withAsync } from './utils/common'

--- a/packages/validators/src/raw/__tests__/and.spec.js
+++ b/packages/validators/src/raw/__tests__/and.spec.js
@@ -1,9 +1,16 @@
 import and from '../and'
+import {
+  F,
+  T,
+  ValidatorResponseT,
+  ValidatorResponseF,
+  NormalizedF,
+  NormalizedT,
+  NormalizedValidatorResponseF,
+  NormalizedValidatorResponseT
+} from '../../../tests/fixtures'
 
 describe('and validator', () => {
-  const T = () => true
-  const F = () => false
-
   it('should not validate no functions', () => {
     expect(and()()).toBe(false)
   })
@@ -32,5 +39,17 @@ describe('and validator', () => {
     const spy = jest.fn()
     and(spy)(1, 2)
     expect(spy).toHaveBeenCalledWith(1, 2)
+  })
+
+  it('should work with functions returning ValidatorResponse', () => {
+    expect(and(ValidatorResponseT, ValidatorResponseT, ValidatorResponseT)()).toBe(true)
+    expect(and(ValidatorResponseF, ValidatorResponseF, ValidatorResponseF)()).toBe(false)
+  })
+
+  it('should work with Normalized Validators', () => {
+    expect(and(NormalizedT, NormalizedT)()).toBe(true)
+    expect(and(NormalizedF, NormalizedF)()).toBe(false)
+    expect(and(NormalizedValidatorResponseT, NormalizedValidatorResponseT)()).toBe(true)
+    expect(and(NormalizedValidatorResponseF, NormalizedValidatorResponseF)()).toBe(false)
   })
 })

--- a/packages/validators/src/raw/__tests__/not.spec.js
+++ b/packages/validators/src/raw/__tests__/not.spec.js
@@ -1,9 +1,16 @@
 import not from '../not'
+import {
+  F,
+  T,
+  ValidatorResponseT,
+  ValidatorResponseF,
+  NormalizedF,
+  NormalizedT,
+  NormalizedValidatorResponseF,
+  NormalizedValidatorResponseT
+} from '../../../tests/fixtures'
 
 describe('not validator', () => {
-  const T = () => true
-  const F = () => false
-
   it('should not validate with true function', () => {
     expect(not(T)('test')).toBe(false)
   })
@@ -24,5 +31,18 @@ describe('not validator', () => {
     const spy = jest.fn()
     not(spy)(1, 2)
     expect(spy).toHaveBeenCalledWith(1, 2)
+  })
+
+  it('should work with functions returning ValidatorResponse', () => {
+    expect(not(ValidatorResponseT)('test')).toBe(false)
+    expect(not(ValidatorResponseT)('')).toBe(true)
+    expect(not(ValidatorResponseF)('test')).toBe(true)
+  })
+
+  it('should work with Normalized Validators', () => {
+    expect(not(NormalizedT)('test')).toBe(false)
+    expect(not(NormalizedF)('')).toBe(true)
+    expect(not(NormalizedValidatorResponseT)('test')).toBe(false)
+    expect(not(NormalizedValidatorResponseF)('')).toBe(true)
   })
 })

--- a/packages/validators/src/raw/__tests__/or.spec.js
+++ b/packages/validators/src/raw/__tests__/or.spec.js
@@ -1,9 +1,16 @@
 import or from '../or'
+import {
+  T,
+  F,
+  NormalizedF,
+  NormalizedT,
+  NormalizedValidatorResponseF,
+  NormalizedValidatorResponseT,
+  ValidatorResponseF,
+  ValidatorResponseT
+} from '../../../tests/fixtures'
 
 describe('or validator', () => {
-  const T = () => true
-  const F = () => false
-
   it('should not validate no functions', () => {
     expect(or()()).toBe(false)
   })
@@ -32,5 +39,17 @@ describe('or validator', () => {
     const spy = jest.fn()
     or(spy)(1, 2)
     expect(spy).toHaveBeenCalledWith(1, 2)
+  })
+
+  it('should work with functions returning ValidatorResponse', () => {
+    expect(or(ValidatorResponseT, ValidatorResponseF, ValidatorResponseF)()).toBe(true)
+    expect(or(ValidatorResponseF, ValidatorResponseF, ValidatorResponseF)()).toBe(false)
+  })
+
+  it('should work with Normalized Validators', () => {
+    expect(or(NormalizedT, NormalizedT)()).toBe(true)
+    expect(or(NormalizedF, NormalizedT)()).toBe(true)
+    expect(or(NormalizedValidatorResponseT, NormalizedValidatorResponseT)()).toBe(true)
+    expect(or(NormalizedValidatorResponseF, NormalizedValidatorResponseT)()).toBe(true)
   })
 })

--- a/packages/validators/src/raw/__tests__/requiredIf.spec.js
+++ b/packages/validators/src/raw/__tests__/requiredIf.spec.js
@@ -1,7 +1,6 @@
 import requiredIf from '../requiredIf'
+import { T, F } from '../../../tests/fixtures'
 
-const T = () => true
-const F = () => false
 const promiseT = () => Promise.resolve(true)
 const promiseF = () => Promise.resolve(false)
 

--- a/packages/validators/src/raw/__tests__/requiredUnless.spec.js
+++ b/packages/validators/src/raw/__tests__/requiredUnless.spec.js
@@ -1,7 +1,5 @@
 import requiredUnless from '../requiredUnless'
-
-const T = () => true
-const F = () => false
+import { T, F } from '../../../tests/fixtures'
 
 describe('requiredUnless validator', () => {
   it('should not validate if prop is falsy', () => {

--- a/packages/validators/src/raw/and.js
+++ b/packages/validators/src/raw/and.js
@@ -1,8 +1,15 @@
-export default (...validators) => {
+import { unwrapNormalizedValidator, unwrapValidatorResponse } from '../utils/common'
+
+/**
+ * Returns true when all validators are truthy
+ * @param {...(NormalizedValidator|Function)} validators
+ * @return {function(...[*]=): boolean}
+ */
+export default function (...validators) {
   return function (...args) {
     return (
       validators.length > 0 &&
-      validators.reduce((valid, fn) => valid && fn.apply(this, args), true)
+      validators.reduce((valid, fn) => valid && unwrapValidatorResponse(unwrapNormalizedValidator(fn).apply(this, args)), true)
     )
   }
 }

--- a/packages/validators/src/raw/between.js
+++ b/packages/validators/src/raw/between.js
@@ -1,9 +1,16 @@
 import { req } from '../common'
 import { unwrap } from '../utils/common'
 
-export default (min, max) =>
-  (value) =>
+/**
+ * Check if a numeric value is between two values.
+ * @param {Ref<Number> | Number} min
+ * @param {Ref<Number> | Number} max
+ * @return {function(*=): boolean}
+ */
+export default function (min, max) {
+  return (value) =>
     !req(value) ||
     ((!/\s/.test(value) || value instanceof Date) &&
       +unwrap(min) <= +value &&
       +unwrap(max) >= +value)
+}

--- a/packages/validators/src/raw/core.js
+++ b/packages/validators/src/raw/core.js
@@ -45,7 +45,9 @@ export const len = (value) => {
  * @param {RegExp} expr
  * @return {function(*=): boolean}
  */
-export const regex = expr => value => {
-  value = unwrap(value)
-  return !req(value) || expr.test(value)
+export function regex (expr) {
+  return value => {
+    value = unwrap(value)
+    return !req(value) || expr.test(value)
+  }
 }

--- a/packages/validators/src/raw/ipAddress.js
+++ b/packages/validators/src/raw/ipAddress.js
@@ -1,6 +1,11 @@
 import { req } from '../common'
 
-export default (value) => {
+/**
+ * Check if a string is an IP Address
+ * @param {String} value
+ * @returns {boolean}
+ */
+export default function (value) {
   if (!req(value)) {
     return true
   }

--- a/packages/validators/src/raw/macAddress.js
+++ b/packages/validators/src/raw/macAddress.js
@@ -1,29 +1,36 @@
 import { req } from '../common'
 import { unwrap } from '../utils/common'
 
-export default (separator = ':') => (value) => {
-  separator = unwrap(separator)
+/**
+ * Check if value is a properly formatted Mac Address.
+ * @param {String | Ref<String>} [separator]
+ * @returns {function(*): boolean}
+ */
+export default function (separator = ':') {
+  return value => {
+    separator = unwrap(separator)
 
-  if (!req(value)) {
-    return true
+    if (!req(value)) {
+      return true
+    }
+
+    if (typeof value !== 'string') {
+      return false
+    }
+
+    const parts =
+      typeof separator === 'string' && separator !== ''
+        ? value.split(separator)
+        : value.length === 12 || value.length === 16
+          ? value.match(/.{2}/g)
+          : null
+
+    return (
+      parts !== null &&
+      (parts.length === 6 || parts.length === 8) &&
+      parts.every(hexValid)
+    )
   }
-
-  if (typeof value !== 'string') {
-    return false
-  }
-
-  const parts =
-    typeof separator === 'string' && separator !== ''
-      ? value.split(separator)
-      : value.length === 12 || value.length === 16
-        ? value.match(/.{2}/g)
-        : null
-
-  return (
-    parts !== null &&
-    (parts.length === 6 || parts.length === 8) &&
-    parts.every(hexValid)
-  )
 }
 
 const hexValid = (hex) => hex.toLowerCase().match(/^[0-9a-f]{2}$/)

--- a/packages/validators/src/raw/maxLength.js
+++ b/packages/validators/src/raw/maxLength.js
@@ -1,5 +1,11 @@
 import { req, len } from '../common'
 import { unwrap } from '../utils/common'
 
-export default (length) =>
-  (value) => !req(value) || len(value) <= unwrap(length)
+/**
+ * Check if provided value has a maximum length
+ * @param {Number | Ref<Number>} length
+ * @returns {function(Array|Object|String): boolean}
+ */
+export default function (length) {
+  return (value) => !req(value) || len(value) <= unwrap(length)
+}

--- a/packages/validators/src/raw/maxValue.js
+++ b/packages/validators/src/raw/maxValue.js
@@ -1,7 +1,13 @@
 import { req } from '../common'
 import { unwrap } from '../utils/common'
 
-export default (max) =>
-  (value) =>
+/**
+ * Check if value is below a threshold.
+ * @param {Number | Ref<Number> | Ref<String>} max
+ * @returns {function(*=): boolean}
+ */
+export default function (max) {
+  return value =>
     !req(value) ||
     ((!/\s/.test(value) || value instanceof Date) && +value <= +unwrap(max))
+}

--- a/packages/validators/src/raw/minLength.js
+++ b/packages/validators/src/raw/minLength.js
@@ -1,4 +1,11 @@
 import { req, len } from './core'
 import { unwrap } from '../utils/common'
 
-export default (length) => value => !req(value) || len(value) >= unwrap(length)
+/**
+ * Check if value is above a threshold.
+ * @param {Number | Ref<Number>} length
+ * @returns {function(Array|Object|String): boolean}
+ */
+export default function (length) {
+  return value => !req(value) || len(value) >= unwrap(length)
+}

--- a/packages/validators/src/raw/minValue.js
+++ b/packages/validators/src/raw/minValue.js
@@ -1,7 +1,13 @@
 import { req } from '../common'
 import { unwrap } from '../utils/common'
 
-export default (min) =>
-  (value) =>
+/**
+ * Check if a value is above a threshold.
+ * @param {String | Number | Ref<Number> | Ref<String>} min
+ * @returns {function(*=): boolean}
+ */
+export default function (min) {
+  return (value) =>
     !req(value) ||
     ((!/\s/.test(value) || value instanceof Date) && +value >= +unwrap(min))
+}

--- a/packages/validators/src/raw/not.js
+++ b/packages/validators/src/raw/not.js
@@ -1,6 +1,13 @@
 import { req } from '../common'
+import { unwrapNormalizedValidator, unwrapValidatorResponse } from '../utils/common'
 
-// TODO: Double check this
-export default (validator) => function (value, vm) {
-  return !req(value) || !validator.call(this, value, vm)
+/**
+ * Swaps the result of a value
+ * @param {NormalizedValidator|Function} validator
+ * @returns {function(*=, *=): boolean}
+ */
+export default function (validator) {
+  return function (value, vm) {
+    return !req(value) || !unwrapValidatorResponse(unwrapNormalizedValidator(validator).call(this, value, vm))
+  }
 }

--- a/packages/validators/src/raw/or.js
+++ b/packages/validators/src/raw/or.js
@@ -1,8 +1,15 @@
-export default (...validators) => {
+import { unwrapNormalizedValidator, unwrapValidatorResponse } from '../utils/common'
+
+/**
+ * Returns true when one of the provided functions returns true.
+ * @param {...(NormalizedValidator|Function)} validators
+ * @return {function(...[*]=): boolean}
+ */
+export default function (...validators) {
   return function (...args) {
     return (
       validators.length > 0 &&
-      validators.reduce((valid, fn) => valid || fn.apply(this, args), false)
+      validators.reduce((valid, fn) => valid || unwrapValidatorResponse(unwrapNormalizedValidator(fn).apply(this, args)), false)
     )
   }
 }

--- a/packages/validators/src/raw/required.js
+++ b/packages/validators/src/raw/required.js
@@ -1,8 +1,13 @@
 import { req } from '../common'
 
-export default (value) => {
+/**
+ * Validates if a value is empty.
+ * @param {String | Array | Date | Object} value
+ * @returns {boolean}
+ */
+export default function (value) {
   if (typeof value === 'string') {
-    return req(value.trim())
+    value = value.trim()
   }
   return req(value)
 }

--- a/packages/validators/src/raw/requiredIf.js
+++ b/packages/validators/src/raw/requiredIf.js
@@ -7,15 +7,17 @@ const validate = (prop, val) => prop ? req(val) : true
  * @param {Boolean | String | function(): (Boolean | Promise<boolean>)} prop
  * @return {function(*): (Boolean | Promise<Boolean>)}
  */
-export default (prop) => (value) => {
-  if (typeof prop !== 'function') {
-    return validate(prop, value)
+export default function (prop) {
+  return (value) => {
+    if (typeof prop !== 'function') {
+      return validate(prop, value)
+    }
+    const result = prop()
+    if (isPromise(result)) {
+      return result.then((response) => {
+        return validate(response, value)
+      })
+    }
+    return validate(result, value)
   }
-  const result = prop()
-  if (isPromise(result)) {
-    return result.then((response) => {
-      return validate(response, value)
-    })
-  }
-  return validate(result, value)
 }

--- a/packages/validators/src/raw/requiredUnless.js
+++ b/packages/validators/src/raw/requiredUnless.js
@@ -3,19 +3,21 @@ import { isPromise } from '../utils/common'
 
 const validate = (prop, val) => !prop ? req(val) : true
 /**
- * Returns required if the passed property is truthy
+ * Returns required if the passed property is falsy.
  * @param {Boolean | String | function(): (Boolean | Promise<boolean>)} prop
  * @return {function(*): (Boolean | Promise<Boolean>)}
  */
-export default (prop) => (value) => {
-  if (typeof prop !== 'function') {
-    return validate(prop, value)
+export default function (prop) {
+  return (value) => {
+    if (typeof prop !== 'function') {
+      return validate(prop, value)
+    }
+    const result = prop()
+    if (isPromise(result)) {
+      return result.then((response) => {
+        return validate(response, value)
+      })
+    }
+    return validate(result, value)
   }
-  const result = prop()
-  if (isPromise(result)) {
-    return result.then((response) => {
-      return validate(response, value)
-    })
-  }
-  return validate(result, value)
 }

--- a/packages/validators/src/raw/sameAs.js
+++ b/packages/validators/src/raw/sameAs.js
@@ -1,3 +1,10 @@
 import { unwrap } from '../utils/common'
 
-export default equalTo => value => unwrap(value) === unwrap(equalTo)
+/**
+ * Check if two values are identical.
+ * @param {*} equalTo
+ * @return {function(*=): boolean}
+ */
+export default function (equalTo) {
+  return value => unwrap(value) === unwrap(equalTo)
+}

--- a/packages/validators/src/utils/common.js
+++ b/packages/validators/src/utils/common.js
@@ -1,4 +1,6 @@
-import { unref } from 'vue-demi'
+import { unref as unwrap } from 'vue-demi'
+
+export { unwrap }
 
 export function isFunction (val) {
   return typeof val === 'function'
@@ -6,15 +8,6 @@ export function isFunction (val) {
 
 export function isObject (o) {
   return o !== null && typeof o === 'object' && !Array.isArray(o)
-}
-
-/**
- * Unwraps a ref, returning its value
- * @param val
- * @return {*}
- */
-export function unwrap (val) {
-  return unref(val)
 }
 
 /**
@@ -49,4 +42,23 @@ export function withAsync (validator) {
   const normalized = normalizeValidatorObject(validator)
   normalized.$async = true
   return normalized
+}
+
+/**
+ * Unwraps a ValidatorResponse object, into a boolean.
+ * @param {ValidatorResponse} result
+ * @return {boolean}
+ */
+export function unwrapValidatorResponse (result) {
+  if (typeof result === 'object') return result.$invalid
+  return result
+}
+
+/**
+ * Unwraps a `NormalizedValidator` object, returning it's validator function.
+ * @param {NormalizedValidator | Function} validator
+ * @return {function}
+ */
+export function unwrapNormalizedValidator (validator) {
+  return validator.$validator || validator
 }

--- a/packages/validators/src/utils/withMessage.js
+++ b/packages/validators/src/utils/withMessage.js
@@ -10,6 +10,7 @@ import { normalizeValidatorObject, isFunction, isObject, unwrap } from './common
  * Attaches a message to a validator
  * @param {MessageCallback | String} $message
  * @param {NormalizedValidator|Function} $validator
+ * @return {NormalizedValidator}
  */
 export default function withMessage ($message, $validator) {
   if (!isFunction($message) && typeof unwrap($message) !== 'string') throw new Error(`[@vuelidate/validators]: First parameter to "withMessage" should be string or a function returning a string, provided ${typeof $message}`)

--- a/packages/validators/src/withMessages/alpha.js
+++ b/packages/validators/src/withMessages/alpha.js
@@ -1,5 +1,9 @@
 import alpha from '../raw/alpha'
 
+/**
+ * Validate if value is alphabetical string.
+ * @type {NormalizedValidator}
+ */
 export default {
   $validator: alpha,
   $message: 'The value is not alphabetical'

--- a/packages/validators/src/withMessages/alphaNum.js
+++ b/packages/validators/src/withMessages/alphaNum.js
@@ -1,5 +1,9 @@
 import alphaNum from '../raw/alphaNum'
 
+/**
+ * Validate if value is alpha-numeric string.
+ * @type {NormalizedValidator}
+ */
 export default {
   $validator: alphaNum,
   $message: 'The value must be alpha-numeric'

--- a/packages/validators/src/withMessages/and.js
+++ b/packages/validators/src/withMessages/and.js
@@ -1,6 +1,13 @@
 import and from '../raw/and'
 
-export default (...validators) => ({
-  $validator: and(...validators),
-  $message: 'The value does not match all of the provided validators'
-})
+/**
+ * Validate if all validators match.
+ * @param {...*} validators
+ * @returns {NormalizedValidator}
+ */
+export default function (...validators) {
+  return {
+    $validator: and(...validators),
+    $message: 'The value does not match all of the provided validators'
+  }
+}

--- a/packages/validators/src/withMessages/between.js
+++ b/packages/validators/src/withMessages/between.js
@@ -1,7 +1,15 @@
 import between from '../raw/between'
 
-export default (min, max) => ({
-  $validator: between(min, max),
-  $message: ({ $params }) => `The value must be between ${$params.min} and ${$params.max}`,
-  $params: { min, max }
-})
+/**
+ * Checks if a value is between two values.
+ * @param {Ref<Number> | Number} min
+ * @param {Ref<Number> | Number} max
+ * @return {NormalizedValidator}
+ */
+export default function (min, max) {
+  return {
+    $validator: between(min, max),
+    $message: ({ $params }) => `The value must be between ${$params.min} and ${$params.max}`,
+    $params: { min, max }
+  }
+}

--- a/packages/validators/src/withMessages/decimal.js
+++ b/packages/validators/src/withMessages/decimal.js
@@ -1,5 +1,9 @@
 import decimal from '../raw/decimal'
 
+/**
+ * Validate if value is decimal number.
+ * @type {NormalizedValidator}
+ */
 export default {
   $validator: decimal,
   $message: 'Value must be decimal'

--- a/packages/validators/src/withMessages/email.js
+++ b/packages/validators/src/withMessages/email.js
@@ -1,5 +1,9 @@
 import email from '../raw/email'
 
+/**
+ * Validate if value is an email.
+ * @type {NormalizedValidator}
+ */
 export default {
   $validator: email,
   $message: 'Value is not a valid email address'

--- a/packages/validators/src/withMessages/integer.js
+++ b/packages/validators/src/withMessages/integer.js
@@ -1,5 +1,9 @@
 import integer from '../raw/integer'
 
+  /**
+   * Validate if value is integer.
+   * @type {NormalizedValidator}
+   */
 export default {
   $validator: integer,
   $message: 'Value is not an integer'

--- a/packages/validators/src/withMessages/ipAddress.js
+++ b/packages/validators/src/withMessages/ipAddress.js
@@ -1,5 +1,9 @@
 import ipAddress from '../raw/ipAddress'
 
+/**
+ * Validate if value is an ipAddress string.
+ * @type {NormalizedValidator}
+ */
 export default {
   $validator: ipAddress,
   $message: 'The value is not a valid IP address'

--- a/packages/validators/src/withMessages/macAddress.js
+++ b/packages/validators/src/withMessages/macAddress.js
@@ -1,6 +1,12 @@
 import macAddress from '../raw/macAddress'
 
-export default (separator) => ({
-  $validator: macAddress(separator),
-  $message: 'The value is not a valid MAC Address'
-})
+/**
+ * Validate if value is a valid Mac Address string.
+ * @returns {NormalizedValidator}
+ */
+export default function (separator) {
+  return {
+    $validator: macAddress(separator),
+    $message: 'The value is not a valid MAC Address'
+  }
+}

--- a/packages/validators/src/withMessages/maxLength.js
+++ b/packages/validators/src/withMessages/maxLength.js
@@ -1,15 +1,14 @@
 import maxLength from '../raw/maxLength'
-// import { withMessage, withParams } from '../common'
 
-export default (max) => ({
-  $validator: maxLength(max),
-  $message: ({ $params }) => `The maximum length allowed is ${$params.max}`,
-  $params: { max }
-})
-
-// Still figuring out which is less error prone
-
-// export default (max) => withMessage(
-//   withParams({ max }, maxLength),
-//   ({ $params }) => `The maximum length allowed is ${$params.max}`
-// )
+/**
+ * Validate the max length of a string.
+ * @param {Number} max
+ * @return {NormalizedValidator}
+ */
+export default function (max) {
+  return {
+    $validator: maxLength(max),
+    $message: ({ $params }) => `The maximum length allowed is ${$params.max}`,
+    $params: { max }
+  }
+}

--- a/packages/validators/src/withMessages/maxValue.js
+++ b/packages/validators/src/withMessages/maxValue.js
@@ -1,5 +1,10 @@
 import maxValue from '../raw/maxValue'
 
+/**
+ * Check if value is below a threshold.
+ * @param {Number | Ref<Number> | Ref<String>} max
+ * @return {NormalizedValidator}
+ */
 export default max => ({
   $validator: maxValue(max),
   $message: ({ $params }) => `The maximum value is ${$params.max}`,

--- a/packages/validators/src/withMessages/minLength.js
+++ b/packages/validators/src/withMessages/minLength.js
@@ -1,7 +1,14 @@
 import minLength from '../raw/minLength'
 
-export default length => ({
-  $validator: minLength(length),
-  $message: ({ $params }) => `This field should be at least ${$params.length} long.`,
-  $params: { length }
-})
+/**
+ * Check if value is above a threshold.
+ * @param {Number | Ref<Number>} length
+ * @returns {NormalizedValidator}
+ */
+export default function (length) {
+  return {
+    $validator: minLength(length),
+    $message: ({ $params }) => `This field should be at least ${$params.length} long.`,
+    $params: { length }
+  }
+}

--- a/packages/validators/src/withMessages/minValue.js
+++ b/packages/validators/src/withMessages/minValue.js
@@ -1,7 +1,14 @@
 import minValue from '../raw/minValue'
 
-export default min => ({
-  $validator: minValue(min),
-  $message: ({ $params }) => `The minimum value allowed is ${$params.min}`,
-  $params: { min }
-})
+/**
+ * Check if a value is above a threshold.
+ * @param {String | Number | Ref<Number> | Ref<String>} min
+ * @returns {NormalizedValidator}
+ */
+export default function (min) {
+  return {
+    $validator: minValue(min),
+    $message: ({ $params }) => `The minimum value allowed is ${$params.min}`,
+    $params: { min }
+  }
+}

--- a/packages/validators/src/withMessages/not.js
+++ b/packages/validators/src/withMessages/not.js
@@ -1,6 +1,13 @@
 import not from '../raw/not'
 
-export default validator => ({
-  $validator: not(validator),
-  $message: `The value does not match the provided validator`
-})
+/**
+ * Swaps the result of a value
+ * @param {NormalizedValidator|Function} validator
+ * @returns {NormalizedValidator}
+ */
+export default function (validator) {
+  return {
+    $validator: not(validator),
+    $message: `The value does not match the provided validator`
+  }
+}

--- a/packages/validators/src/withMessages/numeric.js
+++ b/packages/validators/src/withMessages/numeric.js
@@ -1,5 +1,9 @@
 import numeric from '../raw/numeric'
 
+/**
+ * Check whether a value is numeric.
+ * @type NormalizedValidator
+ */
 export default {
   $validator: numeric,
   $message: 'Value must be numeric'

--- a/packages/validators/src/withMessages/or.js
+++ b/packages/validators/src/withMessages/or.js
@@ -1,6 +1,13 @@
 import or from '../raw/or'
 
-export default (...validators) => ({
-  $validator: or(...validators),
-  $message: 'The value does not match any of the provided validators'
-})
+/**
+ * Returns true when one of the provided functions returns true.
+ * @param {...(NormalizedValidator|Function)} validators
+ * @return {NormalizedValidator}
+ */
+export default function (...validators) {
+  return {
+    $validator: or(...validators),
+    $message: 'The value does not match any of the provided validators'
+  }
+}

--- a/packages/validators/src/withMessages/required.js
+++ b/packages/validators/src/withMessages/required.js
@@ -1,5 +1,9 @@
 import required from '../raw/required'
 
+/**
+ * Check if a value is empty or not.
+ * @type {NormalizedValidator}
+ */
 export default {
   $validator: required,
   $message: 'Value is required'

--- a/packages/validators/src/withMessages/requiredIf.js
+++ b/packages/validators/src/withMessages/requiredIf.js
@@ -1,6 +1,13 @@
 import requiredIf from '../raw/requiredIf'
 
-export default prop => ({
-  $validator: requiredIf(prop),
-  $message: 'The value is required'
-})
+/**
+ * Returns required if the passed property is truthy
+ * @param {Boolean | String | function(): (Boolean | Promise<boolean>)} prop
+ * @return {NormalizedValidator}
+ */
+export default function (prop) {
+  return {
+    $validator: requiredIf(prop),
+    $message: 'The value is required'
+  }
+}

--- a/packages/validators/src/withMessages/requiredUnless.js
+++ b/packages/validators/src/withMessages/requiredUnless.js
@@ -1,5 +1,10 @@
 import requiredUnless from '../raw/requiredUnless'
 
+/**
+ * Returns required unless the passed property is truthy
+ * @param {Boolean | String | function(): (Boolean | Promise<boolean>)} prop
+ * @return {NormalizedValidator}
+ */
 export default prop => ({
   $validator: requiredUnless(prop),
   $message: 'The value is required'

--- a/packages/validators/src/withMessages/sameAs.js
+++ b/packages/validators/src/withMessages/sameAs.js
@@ -1,7 +1,15 @@
 import sameAs from '../raw/sameAs'
 
-export default (equalTo, otherName) => ({
-  $validator: sameAs(equalTo),
-  $message: ({ $params }) => `The value must be equal to the ${otherName} value.`,
-  $params: { equalTo, otherName }
-})
+/**
+ * Check if two values are identical
+ * @param {*} equalTo
+ * @param {String} [otherName]
+ * @return {NormalizedValidator}
+ */
+export default function (equalTo, otherName = 'other') {
+  return {
+    $validator: sameAs(equalTo),
+    $message: ({ $params }) => `The value must be equal to the ${otherName} value.`,
+    $params: { equalTo, otherName }
+  }
+}

--- a/packages/validators/src/withMessages/url.js
+++ b/packages/validators/src/withMessages/url.js
@@ -1,5 +1,9 @@
 import url from '../raw/url'
 
+/**
+ * Check if a value is a url
+ * @type {NormalizedValidator}
+ */
 export default {
   $validator: url,
   $message: 'The value is not a valid URL address'

--- a/packages/validators/tests/fixtures.js
+++ b/packages/validators/tests/fixtures.js
@@ -1,0 +1,8 @@
+export const T = () => true
+export const F = () => false
+export const ValidatorResponseT = () => ({ $invalid: true })
+export const ValidatorResponseF = () => ({ $invalid: false })
+export const NormalizedT = { $validator: T }
+export const NormalizedF = { $validator: F }
+export const NormalizedValidatorResponseT = { $validator: ValidatorResponseT }
+export const NormalizedValidatorResponseF = { $validator: ValidatorResponseF }

--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -5,7 +5,7 @@ import { computed, reactive, ref, watch, isRef } from 'vue-demi'
  * @typedef NormalizedValidator
  * @property {Validator} $validator
  * @property {String | Ref<String> | function(*): string} [$message]
- * @property {Ref<Object>} [$params]
+ * @property {Object | Ref<Object>} [$params]
  */
 
 /**
@@ -22,7 +22,7 @@ import { computed, reactive, ref, watch, isRef } from 'vue-demi'
 
 /**
  * Sorts the validators for a state tree branch
- * @param {Object<NormalizedValidator|Function>} validations
+ * @param {Object<NormalizedValidator|Function>} validationsRaw
  * @return {{ rules: Object<NormalizedValidator>, nestedValidators: Object, config: Object }}
  */
 function sortValidations (validationsRaw = {}) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `next` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Adds `NormalizedValidator` and `ValidatorResponse` support to the `not`, `or` and `and` validators. Refactors all named validators to return actual functions, not variables with fat arrow functions. This is to improve the ES output a bit.

Added JSDoc to pretty much every validator.

There are no breaking changes, only good stuff.