### PR TITLE
Unify minLength validator format

### DIFF
--- a/packages/validators/src/withMessages/minLength.js
+++ b/packages/validators/src/withMessages/minLength.js
@@ -1,7 +1,7 @@
 import minLength from '../raw/minLength'
 
-export default length => ({
-  $validator: minLength(length),
-  $message: ({ $params }) => `This field should be at least ${$params.length} long.`,
-  $params: { length }
+export default (min) => ({
+  $validator: minLength(min),
+  $message: ({ $params }) => `This field should be at least ${$params.min} long.`,
+  $params: { min }
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [X] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [X] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

If you have used the minLength validator with vuelidate 1.0, the format is the same.
If you've used the minLength validator in @vuelidate/validators v<=2.0.0-alpha.2 you may need to update your templates from "$v.name.minLength.$params.length" to "$v.name.minLength.$params.min"
