### PR TITLE
Fix: changed type for VuelidatePlugin to Plugin from vue

### DIFF
--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -1,4 +1,4 @@
-import { Ref, defineComponent } from 'vue-demi';
+import { Ref, defineComponent, Plugin } from 'vue-demi';
 type Component = ReturnType<typeof defineComponent>;
 
 /*
@@ -157,6 +157,6 @@ export const useVuelidate: <
   state: T | Ref<T> | ToRefs<T>,
   registerAs?: string
 ) => Ref<Validation<Vargs>>;
-export const VuelidatePlugin: (app: App) => void;
+export const VuelidatePlugin: Plugin;
 
 export default useVuelidate;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

This was broken in https://github.com/vuelidate/vuelidate/pull/745 and should be fixed now