### PR TITLE
Allow validations passed to useVuelidate to be a function

### DIFF
--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -22,11 +22,13 @@ import { computed, reactive, ref, watch, isRef } from 'vue-demi'
 
 /**
  * Sorts the validators for a state tree branch
- * @param {Object<NormalizedValidator|Function>} validationsRaw
+ * @param {Object<NormalizedValidator|Function>|Function} validationsRaw
  * @return {{ rules: Object<NormalizedValidator>, nestedValidators: Object, config: Object }}
  */
 function sortValidations (validationsRaw = {}) {
-  const validations = unwrap(validationsRaw)
+  const validations = typeof validationsRaw === 'function'
+    ? validationsRaw()
+    : unwrap(validationsRaw)
   const validationKeys = Object.keys(validations)
 
   const rules = {}

--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -13,6 +13,7 @@ import {
 import { createSimpleWrapper, shouldBePristineValidationObj, shouldBeInvalidValidationObject } from '../utils'
 import { withAsync } from '@vuelidate/validators/src/common'
 import useVuelidate from '../../../src'
+import { sameAs } from '@vuelidate/validators/src'
 
 describe('useVuelidate', () => {
   it('should have a `v` key defined if used', () => {
@@ -33,6 +34,25 @@ describe('useVuelidate', () => {
 
     expect(vm.v).toHaveProperty('number', expect.any(Object))
     shouldBePristineValidationObj(vm.v.number)
+  })
+
+  it('accepts a function as validations', async () => {
+    const password = ref('a special password')
+    const confirmPassword = ref('')
+
+    const { vm } = createSimpleWrapper(() => ({
+      confirmPassword: {
+        sameAs: sameAs(password, 'Password')
+      }
+    }), { confirmPassword })
+
+    await vm.v.$validate()
+
+    expect(vm.v.$invalid).toBe(true)
+
+    confirmPassword.value = password.value
+
+    expect(vm.v.$invalid).toBe(false)
   })
 
   describe('.$touch', () => {
@@ -329,8 +349,8 @@ describe('useVuelidate', () => {
       const { state, validations } = nestedReactiveObjectValidation()
       const { vm } = createSimpleWrapper(validations, state)
 
-      vm.v.level1.level2.child.$model = 3;
-      expect(vm.v.$errors.find(error => error.$propertyPath === 'level1.level2.child')).toBeTruthy();
+      vm.v.level1.level2.child.$model = 3
+      expect(vm.v.$errors.find(error => error.$propertyPath === 'level1.level2.child')).toBeTruthy()
     })
 
     it('keeps `$params` reactive', () => {


### PR DESCRIPTION
Somewhat related to https://github.com/vuelidate/vuelidate/issues/589 this PR adds the functionality of being able to pass in a function to `useVuelidate` instead of just a rules object. This allows the validations to be calculated for things that are reactive. I needed this functionality for `sameAs` and added a simple test to check that it works as intended.

I saw the test file was rather large with a lot of empty tests and commented out code, so let me know if I need to put the test in a different spot.

Luckily this wasn't a huge change and we can just call `validationsRaw()` inside `sortValidations` if it is a function. Otherwise the original behavior of `unwrap(validationsRaw)` is performed.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `next` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
