### PR TITLE
feat: allow scoping of component validations, fixes: #719

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "jest-serializer-vue": "^2.0.2",
     "lerna": "^3.18.3",
     "standard-version": "^7.0.1",
-    "vue-demi": "latest",
-    "vue": "^3.0.1"
+    "vue": "^3.0.1",
+    "vue-demi": "latest"
   },
   "dependencies": {
     "lern": "^1.0.0"

--- a/packages/docs/src/advanced_usage.md
+++ b/packages/docs/src/advanced_usage.md
@@ -19,13 +19,17 @@ import { minLength, required } from '@vuelidate/validators'
 export default {
   setup () { return { v$: useVuelidate() } },
   data () {
-    name: 'John',
-    requiredNameLength: 2
+    return {
+      name: 'John',
+      requiredNameLength: 2
+    }
   },
   validations () {
-    name: {
-      minLength: minLength(this.requiredNameLength),
-      required
+    return {
+      name: {
+        minLength: minLength(this.requiredNameLength),
+        required
+      }
     }
   }
 }
@@ -59,9 +63,9 @@ export default {
 
 ## Nested validations
 
-When using `useVuelidate`, Vuelidate will collect all validation `$errors` and `$silentErrors` from all nested components. No need to pass any props or listen to any events. Additionally calling `$touch` in the root component will automatically call `$touch` in the nested components making building complex forms a breeze.
+When using `useVuelidate`, Vuelidate will collect all validation `$errors` and `$silentErrors` from all nested components. No need to pass any props or listen to any events. Additionally, calling `$touch` in the root component will automatically call `$touch` in the nested components, making building complex forms a breeze.
 
-This is the recommended approach when handling collections. Create a new, nested component with it’s own validation rules.
+This is the recommended approach when handling collections. Create a new, nested component with its own validation rules.
 
 ```vue
 <template>
@@ -69,12 +73,12 @@ This is the recommended approach when handling collections. Create a new, nested
     <CompA />
     <CompB />
 
-    // this will contain all $errors and $silentErrors from both <CompA> and <CompB>
+    <!-- this will contain all $errors and $silentErrors from both <CompA> and <CompB>-->
     <p v-for="(error, index) of v.$errors" :key="index">
       {{ error.$message }}
     </p>
   </div>
-<template>
+</template>
 
 <script>
 import { useVuelidate } from '@vuelidate/core'
@@ -82,7 +86,7 @@ import CompA from '@/components/CompA'
 import CompB from '@/components/CompB'
 
 export default {
-  components: { CompA, CompB }
+  components: { CompA, CompB },
   setup () {
     // this will collect all nested component’s validation results
     const v = useVuelidate()
@@ -98,3 +102,88 @@ export default {
 ::: warning
 **BREAKING CHANGE:** The `$each` helper has been removed. Use the above solution (nested validations) instead.
 :::
+
+## Validation scopes
+
+As we learned in [Nested Validations](#nested-validations), you can rely on the parent component to collect validation results from its children. There are cases where we need to limit which forms get collected by the parent.
+
+This is where the `$scope` and `$stopPropagation` properties come in handy. These are configuration settings, that can be passed as a third parameter to the `useVuelidate` composable.
+
+### $scope property
+
+The `$scope` property has three main use cases:
+
+1. `true` (Collect all) - collect results from all and emits to all, this is the default setting. This means that each component that uses `useVuelidate`, can collect results from validation children, and emit to parent components.
+2. `false` (Collect none) - collect no validation results and emit none.
+3. `string` (Specific scope) - collect and emit results, only to/from components, that have the same scope.
+
+**Example using $scope**
+
+```js
+// component that should not collect/emit eny resulsts.
+const IsolatedComponent = {
+  setup(){
+    const validations = {}
+    const state = {}
+    // do not send or collect any validations
+    const v = useVuelidate(validations, state, { $scope: false })
+    return { v }
+  }
+  // .. other stuff
+}
+
+// child component that emits validations
+const ChildComponent = {
+  setup(props) {
+    const validations = {}
+    const state = {}
+    // sends validations to its parent, if it has the same scope.
+    const v = useVuelidate(validations, state, { $scope: props.scope })
+    return { v }
+  },
+  // .. other stuff
+}
+
+// Parent component that collects child validations
+const ParentComponent = {
+  components: { ChildComponent, IsolatedComponent },
+  setup() {
+    const scope = 'foo'
+    const validations = {}
+    const state = {}
+    // collects validations from `ChildComponent` but does not emit it up to parent validations.
+    const v = useVuelidate(validations, state, { $scope: scope })
+    return { v, scope }
+  },
+  template: '<ChildComponent :scope="scope"/><IsolatedComponent />'
+}
+```
+
+### $stopPropagation property
+
+The `$stopPropagation` is used to stop emitting results up to parents, but still collect everything from children. Example use case would be a modal, which has its own validations, and shouldn't emit results to the outer forms.
+
+```js
+export default {
+  components: { ChildComponent },
+  setup() {
+    // collects validations from `ChildComponent` but does not emit it up to parent validations.
+    const v = useVuelidate(validations, state, { $stopPropagation: true })
+    return { v }
+  }
+}
+```
+
+### Collector only components
+
+A collector only component is the top level component, in a chain of form validations. This component is used most often just to show error messages, and has no validation or state.
+
+In such cases, you can just call `useVuelidate` without any parameters, or pass only the configurations object.
+
+```js
+// a collector only component
+export default {
+  setup: () => ({ v: useVuelidate({ $stopPropagation: true }) })
+  // ...other settings
+}
+```

--- a/packages/docs/src/api.md
+++ b/packages/docs/src/api.md
@@ -31,3 +31,10 @@ The presence of those special reserved keywords means that you cannot specify yo
 | `$touch`              | **function** | Sets its property and all nested properties `$dirty` state to true.                                                            |
 | `$getResultsForChild` | **function** | Retrieves the validation results for a nested form component.                                                                  |
 | `$reset`              | **function** | Resets the validation state of a validation tree.                                                                              |
+
+## Validation Configuration
+
+| Name             | Type                 | Description                                                                                                                                                                                                           |
+|------------------|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| $scope           | string\|boolean=true | Defines a scope, which the component will use to collect validation results from child components and push them up to it's parent, with the same scope. `true` means it collects all, `false` means it collects none. |
+| $stopPropagation | boolean=false        | Should the component stop emitting it's results up, no matter the scope. By default it is set to `false`.                                                                                                             |

--- a/packages/vuelidate/src/index.js
+++ b/packages/vuelidate/src/index.js
@@ -6,7 +6,18 @@ import ResultsStorage from './storage'
 const VuelidateInjectChildResults = Symbol('vuelidate#injectChiildResults')
 const VuelidateRemoveChildResults = Symbol('vuelidate#removeChiildResults')
 
-function nestedValidations () {
+export const CollectFlag = {
+  COLLECT_ALL: 1,
+  COLLECT_NONE: 0
+}
+
+/**
+ * Create helpers to collect validation state from child components
+ * @param {Object} params
+ * @param {String | Number} params.$scope - Parent component scope
+ * @return {{sendValidationResultsToParent: function, childResults: ComputedRef<Object>, removeValidationResultsFromParent: function}}
+ */
+function nestedValidations ({ $scope }) {
   const childResultsRaw = {}
   const childResultsKeys = ref([])
   const childResults = computed(() => childResultsKeys.value.reduce((results, key) => {
@@ -17,9 +28,20 @@ function nestedValidations () {
   /**
    * Allows children to send validation data up to their parent.
    * @param {Object} results - the results
-   * @param {String} key - the registeredAs key
+   * @param {Object} args
+   * @param {String} args.$registerAs - the $registeredAs key
+   * @param {String | Number} args.$scope - the $scope key
    */
-  function injectChildResultsIntoParent (results, key) {
+  function injectChildResultsIntoParent (results, { $registerAs: key, $scope: childScope, $stopPropagation }) {
+    if (
+      $stopPropagation ||
+      $scope === CollectFlag.COLLECT_NONE ||
+      childScope === CollectFlag.COLLECT_NONE ||
+      (
+        $scope !== CollectFlag.COLLECT_ALL &&
+        $scope !== childScope
+      )
+    ) return
     childResultsRaw[key] = results
     childResultsKeys.value.push(key)
   }
@@ -35,6 +57,7 @@ function nestedValidations () {
     delete childResultsRaw[key]
   }
 
+  // inject the `injectChildResultsIntoParent` method, into the current scope
   const sendValidationResultsToParent = inject(VuelidateInjectChildResults, () => {})
   // provide to all of it's children the send results to parent function
   provide(VuelidateInjectChildResults, injectChildResultsIntoParent)
@@ -47,15 +70,29 @@ function nestedValidations () {
 }
 
 /**
+ * @typedef GlobalConfig
+ * @property {String} [$registerAs] - Config Object
+ * @property {String | Number | Symbol} [$scope] - A scope to limit child component registration
+ * @property {Boolean} [$stopPropagation] - Tells a Vue component to stop sending it's results up to the parent
+ */
+
+/**
  * Composition API compatible Vuelidate
  * Use inside the `setup` lifecycle hook
- * @param {Object|null} validations - Validations Object
- * @param {Object} state - State object
- * @param {String} globalConfig - Config Object
+ * @param {Object | GlobalConfig} validations - Validations Object or the globalConfig.
+ * @param {Object} [state] - State object - required if `validations` is a validation object.
+ * @param {GlobalConfig} [globalConfig] - Config Object
  * @return {UnwrapRef<*>}
  */
 export function useVuelidate (validations, state, globalConfig = {}) {
-  let { $registerAs } = globalConfig
+  // if we pass only one argument, its most probably the globalConfig.
+  // This use case is so parents can just collect results of child forms.
+  if (arguments.length === 1) {
+    globalConfig = validations
+    validations = undefined
+    state = undefined
+  }
+  let { $registerAs, $scope = CollectFlag.COLLECT_ALL, $stopPropagation } = globalConfig
 
   const instance = getCurrentInstance()
 
@@ -70,7 +107,7 @@ export function useVuelidate (validations, state, globalConfig = {}) {
   const validationResults = ref({})
   const resultsCache = new ResultsStorage()
 
-  const { childResults, sendValidationResultsToParent, removeValidationResultsFromParent } = nestedValidations()
+  const { childResults, sendValidationResultsToParent, removeValidationResultsFromParent } = nestedValidations({ $scope, $stopPropagation })
 
   // Options API
   if (!validations && instance.type.validations) {
@@ -127,7 +164,7 @@ export function useVuelidate (validations, state, globalConfig = {}) {
   }
 
   // send all the data to the parent when the function is invoked inside setup.
-  sendValidationResultsToParent(validationResults, $registerAs)
+  sendValidationResultsToParent(validationResults, { $registerAs, $scope, $stopPropagation })
   // before this component is destroyed, remove all the data from the parent.
   onBeforeUnmount(() => removeValidationResultsFromParent($registerAs))
 

--- a/packages/vuelidate/src/index.js
+++ b/packages/vuelidate/src/index.js
@@ -7,8 +7,8 @@ const VuelidateInjectChildResults = Symbol('vuelidate#injectChiildResults')
 const VuelidateRemoveChildResults = Symbol('vuelidate#removeChiildResults')
 
 export const CollectFlag = {
-  COLLECT_ALL: 1,
-  COLLECT_NONE: 0
+  COLLECT_ALL: true,
+  COLLECT_NONE: false
 }
 
 /**

--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue-demi'
+import { computed, ref, h } from 'vue-demi'
 import { flushPromises, mount } from '@vue/test-utils'
 import { isEven } from '../validators.fixture'
 import {
@@ -10,9 +10,15 @@ import {
   simpleValidation,
   nestedRefObjectValidation
 } from '../validations.fixture'
-import { createSimpleWrapper, shouldBePristineValidationObj, shouldBeInvalidValidationObject, shouldBeErroredValidationObject } from '../utils'
+import {
+  createSimpleWrapper,
+  shouldBePristineValidationObj,
+  shouldBeInvalidValidationObject,
+  shouldBeErroredValidationObject,
+  createSimpleComponent
+} from '../utils'
 import { withAsync } from '@vuelidate/validators/src/common'
-import useVuelidate from '../../../src'
+import useVuelidate, { CollectFlag } from '../../../src'
 
 describe('useVuelidate', () => {
   it('should have a `v` key defined if used', () => {
@@ -335,6 +341,90 @@ describe('useVuelidate', () => {
       expect(childState).toBeFalsy()
       // there are no errors at all
       expect(vm.v.$errors).toEqual([])
+    })
+
+    it('collects all child validation results, if parent `$scope` is not set', async () => {
+      const { childValidationRegisterName, parent, state } = nestedComponentValidation({ childScope: 'child' })
+      const { vm } = mount(parent)
+      shouldBeInvalidValidationObject({ v: vm.v, property: 'number', validatorName: 'isEven' })
+      state.number.value = 3
+      await vm.$nextTick()
+      expect(vm.v.$errors).toHaveLength(1)
+      let childState = vm.v.$getResultsForChild(childValidationRegisterName)
+      expect(childState).toBeTruthy()
+    })
+
+    it('collects all child validation results, if both have the same `$scope`', async () => {
+      const { childValidationRegisterName, parent, state } = nestedComponentValidation({ parentScope: 'sameScope', childScope: 'sameScope' })
+      const { vm } = mount(parent)
+      shouldBeInvalidValidationObject({ v: vm.v, property: 'number', validatorName: 'isEven' })
+      state.number.value = 3
+      await vm.$nextTick()
+      expect(vm.v.$errors).toHaveLength(1)
+      let childState = vm.v.$getResultsForChild(childValidationRegisterName)
+      expect(childState).toBeTruthy()
+    })
+
+    it('does not collect child validation results, if components have different `$scope`', async () => {
+      const { childValidationRegisterName, parent, state } = nestedComponentValidation({ parentScope: 'parent', childScope: 'child' })
+      const { vm } = mount(parent)
+      shouldBePristineValidationObj(vm.v)
+      state.number.value = 3
+      await vm.$nextTick()
+      const childState = vm.v.$getResultsForChild(childValidationRegisterName)
+      expect(childState).toEqual(undefined)
+      expect(vm.v.$errors).toEqual([])
+    })
+
+    it('does not collect child validation, if child `$scope` is `COLLECT_NONE`', async () => {
+      const { childValidationRegisterName, parent, state } = nestedComponentValidation({ childScope: CollectFlag.COLLECT_NONE })
+      const { vm } = mount(parent)
+      shouldBePristineValidationObj(vm.v)
+      state.number.value = 3
+      await vm.$nextTick()
+      const childState = vm.v.$getResultsForChild(childValidationRegisterName)
+      expect(childState).toEqual(undefined)
+      expect(vm.v.$errors).toEqual([])
+    })
+
+    it('does not collect child validations, if parent `$scope` is `COLLECT_NONE`', async () => {
+      const { childValidationRegisterName, parent, state } = nestedComponentValidation({ parentScope: CollectFlag.COLLECT_NONE })
+      const { vm } = mount(parent)
+      shouldBePristineValidationObj(vm.v)
+      state.number.value = 3
+      await vm.$nextTick()
+      const childState = vm.v.$getResultsForChild(childValidationRegisterName)
+      expect(childState).toEqual(undefined)
+      expect(vm.v.$errors).toEqual([])
+    })
+
+    it('stops the propagation of errors up the component chain', () => {
+      const { state, validations } = simpleValidation()
+      let $registerAs = 'componentC'
+      const componentC = createSimpleComponent(() => useVuelidate(validations, state, { $registerAs }))
+      const componentB = {
+        setup: () => ({ v: useVuelidate({ $stopPropagation: true, $lazy: false }) }),
+        render: () => h(componentC)
+      }
+      const componentA = {
+        setup: () => ({ v: useVuelidate() }),
+        render: () => h(componentB)
+      }
+      // mount the top most component
+      const wrapper = mount(componentA)
+      // make sure it has no errors
+      expect(wrapper.vm.v.$silentErrors).toHaveLength(0)
+      // make sure the child component is not registered at all
+      expect(wrapper.vm.v.$getResultsForChild($registerAs)).toBeFalsy()
+
+      // find componentB
+      let componentCVueWrapper = wrapper.findComponent(componentB)
+      // make sure it has errors
+      expect(componentCVueWrapper.vm.v.$silentErrors).toHaveLength(1)
+      // make sure that componentC is registered
+      expect(componentCVueWrapper.vm.v.$getResultsForChild($registerAs)).toBeTruthy()
+      // make sure that componentC has errors
+      expect(wrapper.findComponent(componentC).vm.v.$silentErrors).toHaveLength(1)
     })
   })
 

--- a/packages/vuelidate/test/unit/validations.fixture.js
+++ b/packages/vuelidate/test/unit/validations.fixture.js
@@ -82,19 +82,19 @@ export function computedValidationsObjectWithReactive () {
   }
 }
 
-export function nestedComponentValidation ({ state: origState, validations: origValidations } = {}) {
+export function nestedComponentValidation ({ state: origState, validations: origValidations, parentScope, childScope } = {}) {
   const state = origState || { number: ref(1) }
   const validations = origValidations || { number: { isEven, $autoDirty: true } }
   const childValidationRegisterName = 'child-validation'
 
   const ChildComponent = createSimpleComponent(() =>
-    useVuelidate(validations, state, { $registerAs: childValidationRegisterName })
+    useVuelidate(validations, state, { $registerAs: childValidationRegisterName, $scope: childScope })
   )
 
   const parent = {
     name: 'ParentWithChildForm',
     setup () {
-      const v = useVuelidate()
+      const v = useVuelidate({ $scope: parentScope })
       const shouldRenderChild = ref(true)
       return {
         v,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4040,9 +4040,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001135:
-  version "1.0.30001142"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001142.tgz#a8518fdb5fee03ad95ac9f32a9a1e5999469c250"
-  integrity sha512-pDPpn9ankEpBFZXyCv2I4lh1v/ju+bqb78QfKf+w9XgDAFWBwSYPswXqprRdrgQWK0wQnpIbfwRjNHO1HWqvoQ==
+  version "1.0.30001181"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001181.tgz"
+  integrity sha512-m5ul/ARCX50JB8BSNM+oiPmQrR5UmngaQ3QThTTp5HcIIQGP/nPBs82BYLE+tigzm3VW+F4BJIhUyaVtEweelQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This PR allows adding a scope to your validations, limiting the parent/child collection of validation results.

1. Parent collects all by default.
2. Child can specify it does not want to be collected.
3. If parent and child scope is the same, validations get collected.
4. If parent is set to collect all, child scope does not matter.


### $scope

The `$scope` global property allows closely connecting component forms.

```js
const Child = {
  name: 'child',
  setup() {
    return { v: useVuelidate(state, validations, { $scope: 'form-X' }) }
  }
}
```

```js
const Parent = {
  name: 'parent',
  setup: () => ({ v: useVuelidate(state, validations, { $scope: 'foo' }) })
  components: { Child }
}
```

### $stopPropagation

The `$stopPropagation` allows stopping a component from sending it's result up to it's parent.