### PR TITLE
refactor: all validators are async by default, removes withAsync helper

### DIFF
--- a/packages/docs/src/.vitepress/config.js
+++ b/packages/docs/src/.vitepress/config.js
@@ -17,7 +17,7 @@ const config = {
       { text: 'Getting started', link: '/' },
       { text: 'Guide', link: '/guide' },
       { text: 'Advanced Usage', link: '/advanced_usage' },
-      { text: 'Examples', link: '/examples' },
+      { text: 'Examples (outdated)', link: '/examples' },
       { text: 'API', link: '/api' },
       { text: 'Built-in Validators', link: '/validators' },
       { text: 'Custom Validators', link: '/custom_validators' },

--- a/packages/docs/src/.vitepress/theme/components/AsComposition.vue
+++ b/packages/docs/src/.vitepress/theme/components/AsComposition.vue
@@ -31,7 +31,6 @@
 import { ref, reactive } from 'vue'
 import useVuelidate from '@vuelidate/core'
 import { required, minLength, sameAs, helpers } from '@vuelidate/validators'
-import { withAsync } from '@vuelidate/validators/src/common'
 
 const { withMessage, withParams, unwrap } = helpers
 
@@ -62,7 +61,7 @@ function usePassword ({ minimumLength }) {
       ),
       asyncValidator: withMessage(
         ({ $pending, $model }) => $pending ? 'Checking!' : `Error! ${$model} Isn’t "aaaa"`,
-        withAsync(asyncValidator)
+        asyncValidator
       ),
       $autoDirty: true
     },

--- a/packages/docs/src/examples.md
+++ b/packages/docs/src/examples.md
@@ -38,7 +38,7 @@ If you want to create a validator that groups many otherwise unrelated fields to
 
 ## Collections validation
 
-Array support with `$each` keyword
+Use nested component validations.
 
 > Example
 
@@ -50,16 +50,33 @@ Any component's data has to be accessed synchronously for correct reactive behav
 
 Validator is evaluated on every data change, as it is essentially a computed value. If you need to throttle an async call, do it on your data change event, not on the validator itself. You may end up with broken Vue observables otherwise.
 
-> Example
+```js
+const asyncEmailValidator = (v) => Promise.resolve() // does something async
+export default {
+  validations () {
+    return {
+      email: {
+        isUnique: asyncEmailValidator
+      }
+    }
+  }
+}
+```
 
 The `async/await` syntax is fully supported. It works especially great in combination with Fetch API.
 
 ```js
-validations: {
-  async isUnique (value) {
-    if (value === '') return true
-    const response = await fetch(`/api/unique/${value}`)
-    return Boolean(await response.json())
+export default {
+  validations () {
+    return {
+      email: {
+        async isUnique (value) {
+          if (value === '') return true
+          const response = await fetch(`/api/unique/${value}`)
+          return Boolean(await response.json())
+        }
+      }
+    }
   }
 }
 ```

--- a/packages/test-project/src/components/SimpleForm.vue
+++ b/packages/test-project/src/components/SimpleForm.vue
@@ -42,9 +42,7 @@ import { ref, reactive, computed } from 'vue'
 import useVuelidate from '@vuelidate/core'
 import { required, helpers, minLength } from '@vuelidate/validators'
 
-const { withAsync } = helpers
-
-const asyncValidator = withAsync({
+const asyncValidator = {
   $message: 'Should be aaaa',
   $validator: (v) => {
     return new Promise(resolve => {
@@ -55,7 +53,7 @@ const asyncValidator = withAsync({
       }, 2000)
     })
   }
-})
+}
 
 export default {
   name: 'SimpleForm',

--- a/packages/validators/src/common.js
+++ b/packages/validators/src/common.js
@@ -1,4 +1,4 @@
 export { default as withParams } from './utils/withParams'
 export { default as withMessage } from './utils/withMessage'
 export { req, len, regex } from './raw/core'
-export { unwrap, withAsync } from './utils/common'
+export { unwrap } from './utils/common'

--- a/packages/validators/src/utils/__tests__/common.spec.js
+++ b/packages/validators/src/utils/__tests__/common.spec.js
@@ -1,5 +1,5 @@
 import { ref } from 'vue-demi'
-import { normalizeValidatorObject, isTruthy, unwrap, isObject, isFunction, withAsync } from '../common'
+import { normalizeValidatorObject, isTruthy, unwrap, isObject, isFunction } from '../common'
 
 describe('common', () => {
   describe('isFunction', () => {
@@ -59,25 +59,6 @@ describe('common', () => {
       const fn = jest.fn(() => true)
       expect(isTruthy(fn)).toBe(true)
       expect(fn).toHaveBeenCalled()
-    })
-  })
-
-  describe('withAsync', () => {
-    const T = () => true
-    it('wraps a function in an async object', () => {
-      expect(withAsync(T)).toEqual({
-        $async: true,
-        $validator: T
-      })
-    })
-
-    it('wraps a validator object into an async validator', () => {
-      const validator = { $validator: T, $message: 'Truthy' }
-      expect(withAsync(validator)).toEqual({
-        $async: true,
-        $validator: T,
-        $message: 'Truthy'
-      })
     })
   })
 })

--- a/packages/validators/src/utils/common.js
+++ b/packages/validators/src/utils/common.js
@@ -38,12 +38,6 @@ export function isPromise (object) {
   return isObject(object) && isFunction(object.then)
 }
 
-export function withAsync (validator) {
-  const normalized = normalizeValidatorObject(validator)
-  normalized.$async = true
-  return normalized
-}
-
 /**
  * Unwraps a ValidatorResponse object, into a boolean.
  * @param {ValidatorResponse} result

--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -211,7 +211,10 @@ function createValidationResults (rules, model, key, resultsCache, path, config)
   if (cachedResult) {
     // if the rules are the same as before, use the cached results
     if (!cachedResult.$partial) return cachedResult
+    // remove old watchers
     cachedResult.$unwatch()
+    // invalidate the validators, as they are now unwatched
+    resultsCache.invalidateValidatorAt(path)
     // use the `$dirty.value`, so we dont save references by accident
     $dirty.value = cachedResult.$dirty.value
   }

--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -1,6 +1,5 @@
 import { isFunction, unwrap, unwrapObj } from './utils'
-import { computed, isRef, reactive, ref, watch } from 'vue-demi'
-import { nextTick } from 'vue'
+import { computed, isRef, reactive, ref, watch, nextTick } from 'vue-demi'
 
 let ROOT_PATH = '__root'
 

--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -213,8 +213,6 @@ function createValidationResults (rules, model, key, resultsCache, path, config)
     if (!cachedResult.$partial) return cachedResult
     // remove old watchers
     cachedResult.$unwatch()
-    // invalidate the validators, as they are now unwatched
-    resultsCache.invalidateValidatorAt(path)
     // use the `$dirty.value`, so we dont save references by accident
     $dirty.value = cachedResult.$dirty.value
   }
@@ -231,7 +229,12 @@ function createValidationResults (rules, model, key, resultsCache, path, config)
    * If there are no validation rules, it is most likely
    * a top level state, aka root
    */
-  if (!ruleKeys.length) return result
+  if (!ruleKeys.length) {
+    // if there are cached results, we should overwrite them with the new ones
+    cachedResult && resultsCache.set(path, rules, result)
+
+    return result
+  }
 
   ruleKeys.forEach(ruleKey => {
     result[ruleKey] = createValidatorResult(

--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -1,4 +1,4 @@
-import { isFunction, isPromise, unwrap, unwrapObj, isProxy } from './utils'
+import { isFunction, unwrap, unwrapObj } from './utils'
 import { computed, isRef, reactive, ref, watch } from 'vue-demi'
 import { nextTick } from 'vue'
 
@@ -521,9 +521,13 @@ export function setValidations ({
   }) : null
 
   if (key && mergedConfig.$autoDirty) {
-    watch(nestedState, () => {
+    const $unwatch = watch(nestedState, () => {
+      const autoDirtyPath = `_${path}_$watcher_`
+      const cachedAutoDirty = resultsCache.get(autoDirtyPath, {})
       if (!$dirty.value) $touch()
-    })
+      if (cachedAutoDirty) cachedAutoDirty.$unwatch()
+      resultsCache.set(autoDirtyPath, {}, { $unwatch })
+    }, { flush: 'sync' })
   }
 
   /**

--- a/packages/vuelidate/src/storage.js
+++ b/packages/vuelidate/src/storage.js
@@ -13,21 +13,6 @@ export default class ResultsStorage {
     this.storage.set(path, { rules, result })
   }
 
-  invalidateValidatorAt (path) {
-    const storedRuleResultPair = this.storage.get(path)
-    if (!storedRuleResultPair) return undefined
-
-    const { result } = storedRuleResultPair
-
-    this.storage.set(path, {
-      rules: {},
-      result: {
-        $dirty: result.$dirty,
-        $unwatch: () => {}
-      }
-    })
-  }
-
   /**
    * Check if the stored `results` for the provided `path` have the same `rules` compared to 'storedRules'
    * @param {String} path
@@ -44,14 +29,12 @@ export default class ResultsStorage {
     const hasAllValidators = newRulesKeys.every(ruleKey => storedRulesKeys.includes(ruleKey))
     if (!hasAllValidators) return false
 
-    const hasSameParams = newRulesKeys.every(ruleKey => {
+    return newRulesKeys.every(ruleKey => {
       if (!rules[ruleKey].$params) return true
       Object.keys(rules[ruleKey].$params).every(paramKey => {
         return storedRules[ruleKey].$params[paramKey] === rules[ruleKey].$params[paramKey]
       })
     })
-    if (!hasSameParams) return false
-    return true
   }
 
   /**
@@ -67,7 +50,9 @@ export default class ResultsStorage {
 
     const isValidCache = this.checkRulesValidity(path, rules, storedRules)
 
-    if (!isValidCache) return { $dirty: result.$dirty, $partial: true, $unwatch: result.$unwatch }
+    const $unwatch = result.$unwatch ? result.$unwatch : () => ({})
+
+    if (!isValidCache) return { $dirty: result.$dirty, $partial: true, $unwatch }
     return result
   }
 }

--- a/packages/vuelidate/src/storage.js
+++ b/packages/vuelidate/src/storage.js
@@ -13,6 +13,21 @@ export default class ResultsStorage {
     this.storage.set(path, { rules, result })
   }
 
+  invalidateValidatorAt (path) {
+    const storedRuleResultPair = this.storage.get(path)
+    if (!storedRuleResultPair) return undefined
+
+    const { result } = storedRuleResultPair
+
+    this.storage.set(path, {
+      rules: {},
+      result: {
+        $dirty: result.$dirty,
+        $unwatch: () => {}
+      }
+    })
+  }
+
   /**
    * Check if the stored `results` for the provided `path` have the same `rules` compared to 'storedRules'
    * @param {String} path

--- a/packages/vuelidate/src/storage.js
+++ b/packages/vuelidate/src/storage.js
@@ -52,7 +52,7 @@ export default class ResultsStorage {
 
     const isValidCache = this.checkRulesValidity(path, rules, storedRules)
 
-    if (!isValidCache) return { $dirty: result.$dirty, $partial: true }
+    if (!isValidCache) return { $dirty: result.$dirty, $partial: true, $unwatch: result.$unwatch }
     return result
   }
 }

--- a/packages/vuelidate/test/unit/specs/optionsApi.spec.js
+++ b/packages/vuelidate/test/unit/specs/optionsApi.spec.js
@@ -1,4 +1,4 @@
-import { ref } from 'vue-demi'
+import { ref, nextTick } from 'vue-demi'
 import { isEven, isOdd } from '../validators.fixture'
 import {
   createOldApiSimpleWrapper,
@@ -13,8 +13,7 @@ import {
   nestedRefObjectValidation,
   nestedReactiveObjectValidation
 } from '../validations.fixture'
-import { flushPromises, mount } from '@vue/test-utils'
-import { nextTick } from 'vue'
+import { flushPromises, mount } from '../test-utils'
 
 describe('OptionsAPI validations', () => {
   it('should have a `v` key defined if used', async () => {

--- a/packages/vuelidate/test/unit/specs/optionsApi.spec.js
+++ b/packages/vuelidate/test/unit/specs/optionsApi.spec.js
@@ -13,33 +13,32 @@ import {
   nestedRefObjectValidation,
   nestedReactiveObjectValidation
 } from '../validations.fixture'
-import { flushPromises, mount } from '../test-utils'
-import useVuelidate from '../../../src'
-import { withAsync } from '@vuelidate/validators/src/common'
+import { flushPromises, mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
 
 describe('OptionsAPI validations', () => {
-  it('should have a `v` key defined if used', () => {
-    const { vm } = createOldApiSimpleWrapper({}, {})
+  it('should have a `v` key defined if used', async () => {
+    const { vm } = await createOldApiSimpleWrapper({}, {})
 
     expect(vm.v).toEqual(expect.any(Object))
   })
 
-  it('should return a pristine validation object', () => {
-    const { vm } = createOldApiSimpleWrapper({}, {})
+  it('should return a pristine validation object', async () => {
+    const { vm } = await createOldApiSimpleWrapper({}, {})
 
     shouldBePristineValidationObj(vm.v)
   })
 
-  it('should return a pristine validation object for a property using ref', () => {
+  it('should return a pristine validation object for a property using ref', async () => {
     const number = ref(2)
-    const { vm } = createOldApiSimpleWrapper({ number: { isEven } }, { number })
+    const { vm } = await createOldApiSimpleWrapper({ number: { isEven } }, { number })
 
     expect(vm.v).toHaveProperty('number', expect.any(Object))
     shouldBePristineValidationObj(vm.v.number)
   })
 
-  it('should return a pristine validation object for a property', () => {
-    const { vm } = createOldApiSimpleWrapper({ number: { isEven } }, { number: 2 })
+  it('should return a pristine validation object for a property', async () => {
+    const { vm } = await createOldApiSimpleWrapper({ number: { isEven } }, { number: 2 })
 
     expect(vm.v).toHaveProperty('number', expect.any(Object))
     shouldBePristineValidationObj(vm.v.number)
@@ -47,7 +46,7 @@ describe('OptionsAPI validations', () => {
 
   describe('$model', () => {
     it('should update the source value', async () => {
-      const { vm } = createOldApiSimpleWrapper({ number: { isEven } }, { number: 1 })
+      const { vm } = await createOldApiSimpleWrapper({ number: { isEven } }, { number: 1 })
 
       vm.v.number.$model = 3
       await vm.$nextTick()
@@ -55,7 +54,7 @@ describe('OptionsAPI validations', () => {
     })
 
     it('should update the $dirty state to true when $model value changes', async () => {
-      const { vm } = createOldApiSimpleWrapper({ number: { isEven } }, { number: 2 })
+      const { vm } = await createOldApiSimpleWrapper({ number: { isEven } }, { number: 2 })
       shouldBePristineValidationObj(vm.v.number)
 
       vm.v.number.$model = 3
@@ -75,6 +74,7 @@ describe('OptionsAPI validations', () => {
     it('should collect child validations when they invalidate', async () => {
       const { state, parent } = nestedComponentValidation()
       const wrapper = mount(parent)
+      await wrapper.vm.$nextTick()
       shouldBeInvalidValidationObject({ v: wrapper.vm.v, property: 'number', validatorName: 'isEven' })
       state.number.value = 3
       await wrapper.vm.$nextTick()
@@ -92,6 +92,8 @@ describe('OptionsAPI validations', () => {
     it('should return false on $validate() if nested component validation is invalid', async () => {
       const { state, parent } = nestedComponentValidation()
       const wrapper = mount(parent)
+      await wrapper.vm.$nextTick()
+
       shouldBeInvalidValidationObject({ v: wrapper.vm.v, property: 'number', validatorName: 'isEven' })
       // make the validation fail
       state.number.value = 3
@@ -105,6 +107,8 @@ describe('OptionsAPI validations', () => {
     it('removes the child results if the child gets destroyed', async () => {
       const { childValidationRegisterName, parent, state } = nestedComponentValidation()
       const { vm } = mount(parent)
+      await vm.$nextTick()
+
       // make sure the validation object is clear
       shouldBeInvalidValidationObject({ v: vm.v, property: 'number', validatorName: 'isEven' })
       state.number.value = 3
@@ -125,6 +129,7 @@ describe('OptionsAPI validations', () => {
     it('returns the validation results for a child component', async () => {
       const { childValidationRegisterName, parent, state } = nestedComponentValidation()
       const { vm } = mount(parent)
+      await vm.$nextTick()
       shouldBeInvalidValidationObject({ v: vm.v, property: 'number', validatorName: 'isEven' })
       state.number.value = 3
       await vm.$nextTick()
@@ -140,9 +145,9 @@ describe('OptionsAPI validations', () => {
       })
     })
 
-    it('is only preset at the top level', () => {
+    it('is only preset at the top level', async () => {
       const { state, validations } = nestedReactiveObjectValidation()
-      const { vm } = createOldApiSimpleWrapper(validations, state)
+      const { vm } = await createOldApiSimpleWrapper(validations, state)
       expect(vm.v).toHaveProperty('$getResultsForChild')
       expect(vm.v.level0).not.toHaveProperty('$getResultsForChild')
       expect(vm.v.level1).not.toHaveProperty('$getResultsForChild')
@@ -164,7 +169,7 @@ describe('OptionsAPI validations', () => {
         }
         return { number: { isEven } }
       }
-      const wrapper = createOldApiSimpleWrapper(validation, { number: 2, condition: true })
+      const wrapper = await createOldApiSimpleWrapper(validation, { number: 2, condition: true })
 
       expect(wrapper.vm.v).toHaveProperty('number', expect.any(Object))
       shouldBeInvalidValidationObject({ v: wrapper.vm.v, property: 'number', validatorName: 'isOdd' })
@@ -177,7 +182,7 @@ describe('OptionsAPI validations', () => {
         }
         return { number: { isEven } }
       }
-      const wrapper = createOldApiSimpleWrapper(validation, { number: 2, condition: false })
+      const wrapper = await createOldApiSimpleWrapper(validation, { number: 2, condition: false })
 
       expect(wrapper.vm.v).toHaveProperty('number', expect.any(Object))
       shouldBePristineValidationObj(wrapper.vm.v.number)
@@ -204,33 +209,26 @@ describe('OptionsAPI validations', () => {
     it('supports async validators via `$async: true` object syntax', async () => {
       jest.useFakeTimers()
       const { state, validations } = asyncValidation()
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
       vm.v.$touch()
-      await flushPromises()
+      await nextTick()
+      jest.advanceTimersByTime(6)
+      await nextTick()
       expect(vm.v.number.asyncIsEven.$pending).toBe(false)
       state.number.value = 6
+      await nextTick()
+
       expect(vm.v.number.asyncIsEven.$pending).toBe(true)
       expect(vm.v.number.$invalid).toBe(true)
-      await flushPromises()
+
+      jest.advanceTimersByTime(6)
+      await nextTick()
+
       expect(vm.v.number.asyncIsEven.$pending).toBe(false)
       expect(vm.v.number.$invalid).toBe(false)
       jest.useRealTimers()
     })
 
-    it('throws when passed an async validator directly', () => {
-      const asyncValidator = (v) => Promise.resolve(v)
-      const number = ref(0)
-      const component = {
-        template: '<div>Hello World</div>',
-        setup () {
-          const v = useVuelidate({ number: { asyncValidator } }, { number })
-          return { v }
-        }
-      }
-      const { vm } = mount(component)
-      // throws here, because we call the `$invalid` getter.
-      expect(() => vm.v.$touch).toThrowError()
-    })
     //
     // TODO: Fix this one
     // it('allows multiple invocations of an async validator, the last one to resolve, sets the return value', async () => {
@@ -267,7 +265,7 @@ describe('OptionsAPI validations', () => {
     it('trigger $dirty and $model reactions', async () => {
       const { state, validations } = nestedRefObjectValidation()
 
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
 
       expect(vm.v.level1.level2.child).toHaveProperty('$model', 2)
       expect(vm.v.level1.level2.child).toHaveProperty('$dirty', false)
@@ -293,7 +291,7 @@ describe('OptionsAPI validations', () => {
     it('trigger $invalid reactions', async () => {
       const { state, validations } = nestedRefObjectValidation()
 
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
 
       vm.v.level1.level2.child.$touch()
       expect(vm.v.level1.level2.child).toHaveProperty('$invalid', false)
@@ -307,6 +305,7 @@ describe('OptionsAPI validations', () => {
           }
         }
       }
+      await vm.$nextTick()
 
       expect(vm.v.level1.level2.child).toHaveProperty('$invalid', true)
     })

--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -18,41 +18,41 @@ import {
   shouldBeErroredValidationObject,
   createSimpleComponent
 } from '../utils'
-import { withAsync } from '@vuelidate/validators/src/common'
 import useVuelidate, { CollectFlag } from '../../../src'
+import { nextTick } from 'vue'
 
 describe('useVuelidate', () => {
-  it('should have a `v` key defined if used', () => {
-    const wrapper = createSimpleWrapper({}, {})
+  it('should have a `v` key defined if used', async () => {
+    const wrapper = await createSimpleWrapper({}, {})
 
     expect(wrapper.vm.v).toEqual(expect.any(Object))
   })
 
-  it('does not error out if invoked without any parameters', () => {
+  it('does not error out if invoked without any parameters', async () => {
     const warnSpy = jest.spyOn(console, 'warn')
-    const { vm } = createSimpleWrapper()
+    const { vm } = await createSimpleWrapper()
 
     expect(warnSpy).toHaveBeenCalledTimes(0)
     shouldBePristineValidationObj(vm.v)
   })
 
-  it('should return a pristine validation object', () => {
-    const { vm } = createSimpleWrapper({}, {})
+  it('should return a pristine validation object', async () => {
+    const { vm } = await createSimpleWrapper({}, {})
 
     shouldBePristineValidationObj(vm.v)
   })
 
-  it('should return a pristine validation object for a property', () => {
+  it('should return a pristine validation object for a property', async () => {
     const number = ref(2)
-    const { vm } = createSimpleWrapper({ number: { isEven } }, { number })
+    const { vm } = await createSimpleWrapper({ number: { isEven } }, { number })
 
     expect(vm.v).toHaveProperty('number', expect.any(Object))
     shouldBePristineValidationObj(vm.v.number)
   })
 
-  it('should set the parent `$dirty` prop to true, when all children are dirty', () => {
+  it('should set the parent `$dirty` prop to true, when all children are dirty', async () => {
     const { state, validations } = nestedReactiveObjectValidation()
-    const { vm } = createSimpleWrapper(validations, state)
+    const { vm } = await createSimpleWrapper(validations, state)
 
     expect(vm.v.$dirty).toBe(false)
     expect(vm.v.level0.$dirty).toBe(false)
@@ -69,20 +69,21 @@ describe('useVuelidate', () => {
   })
 
   describe('.$touch', () => {
-    it('should update the `$dirty` state to `true`, on used property', () => {
+    it('should update the `$dirty` state to `true`, on used property', async () => {
       const { state, validations } = simpleValidation()
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
 
       shouldBeInvalidValidationObject({ v: vm.v.number, property: 'number', validatorName: 'isEven' })
 
       vm.v.number.$touch()
+      await vm.$nextTick()
       shouldBeErroredValidationObject({ v: vm.v.number, property: 'number', validatorName: 'isEven' })
     })
 
-    it('should update the `$dirty` state to `true` on all nested properties', () => {
+    it('should update the `$dirty` state to `true` on all nested properties', async () => {
       const number = ref(1)
       const number2 = ref(1)
-      const { vm } = createSimpleWrapper(
+      const { vm } = await createSimpleWrapper(
         { parent: { number: { isEven } }, number2: { isEven } },
         { parent: { number }, number2 }
       )
@@ -99,10 +100,10 @@ describe('useVuelidate', () => {
       shouldBeInvalidValidationObject({ v: vm.v.number2, property: 'number2', propertyPath: 'number2', validatorName: 'isEven' })
     })
 
-    it('should not update the `$dirty` state on the property it wasnt used on', () => {
+    it('should not update the `$dirty` state on the property it wasnt used on', async () => {
       const numberA = ref(1)
       const numberB = ref(1)
-      const { vm } = createSimpleWrapper(
+      const { vm } = await createSimpleWrapper(
         { numberA: { isEven }, numberB: { isEven } },
         { numberA, numberB }
       )
@@ -125,10 +126,10 @@ describe('useVuelidate', () => {
       }])
     })
 
-    it('should update the `$dirty` state to `true` on all properties, when used on top level node', () => {
+    it('should update the `$dirty` state to `true` on all properties, when used on top level node', async () => {
       const number = ref(1)
       const number2 = ref(1)
-      const { vm } = createSimpleWrapper(
+      const { vm } = await createSimpleWrapper(
         { parent: { number: { isEven } }, number2: { isEven } },
         { parent: { number }, number2 }
       )
@@ -143,7 +144,7 @@ describe('useVuelidate', () => {
     it('should update the `$dirty` state even if being cached before hand', async () => {
       const { state, validations } = computedValidationsObjectWithRefs()
       const { number, conditional } = state
-      const { vm } = createSimpleWrapper(validations, { number })
+      const { vm } = await createSimpleWrapper(validations, { number })
       expect(vm.v.number).toHaveProperty('$dirty', false)
       conditional.value = 10
       // await the async watcher to pass
@@ -160,9 +161,9 @@ describe('useVuelidate', () => {
   })
 
   describe('.$reset', () => {
-    it('should update the $dirty state to false', () => {
+    it('should update the $dirty state to false', async () => {
       const number = ref(1)
-      const { vm } = createSimpleWrapper({ number: { isEven } }, { number })
+      const { vm } = await createSimpleWrapper({ number: { isEven } }, { number })
       shouldBeInvalidValidationObject({ v: vm.v.number, property: 'number', validatorName: 'isEven' })
 
       vm.v.number.$touch()
@@ -172,10 +173,10 @@ describe('useVuelidate', () => {
       shouldBeInvalidValidationObject({ v: vm.v.number, property: 'number', validatorName: 'isEven' })
     })
 
-    it('should update the $dirty state to false, only on the current property', () => {
+    it('should update the $dirty state to false, only on the current property', async () => {
       const numberA = ref(1)
       const numberB = ref(1)
-      const { vm } = createSimpleWrapper(
+      const { vm } = await createSimpleWrapper(
         {
           numberA: { isEven },
           numberB: { isEven }
@@ -196,10 +197,10 @@ describe('useVuelidate', () => {
       shouldBeErroredValidationObject({ v: vm.v.numberB, property: 'numberB', validatorName: 'isEven' })
     })
 
-    it('should reset all the properties back to pristine condition, including nested ones', () => {
+    it('should reset all the properties back to pristine condition, including nested ones', async () => {
       const numberA = ref(1)
       const numberB = ref(1)
-      const { vm } = createSimpleWrapper(
+      const { vm } = await createSimpleWrapper(
         {
           parent: { numberA: { isEven } },
           numberB: { isEven }
@@ -223,7 +224,7 @@ describe('useVuelidate', () => {
     it('should reset even after coming back from cache', async () => {
       const { state, validations } = computedValidationsObjectWithRefs()
       const { number, conditional } = state
-      const { vm } = createSimpleWrapper(validations, { number })
+      const { vm } = await createSimpleWrapper(validations, { number })
       vm.v.number.$touch()
       expect(vm.v.number).toHaveProperty('$dirty', true)
       conditional.value = 10
@@ -240,7 +241,7 @@ describe('useVuelidate', () => {
   describe('$autoDirty', () => {
     it('should update the $dirty state to true when value changes', async () => {
       const number = ref(1)
-      const { vm } = createSimpleWrapper({ number: { isEven, $autoDirty: true } }, { number })
+      const { vm } = await createSimpleWrapper({ number: { isEven, $autoDirty: true } }, { number })
       shouldBeInvalidValidationObject({ v: vm.v.number, property: 'number', validatorName: 'isEven' })
 
       number.value = 3
@@ -293,7 +294,7 @@ describe('useVuelidate', () => {
   describe('$model', () => {
     it('should update the source value', async () => {
       const number = ref(1)
-      const { vm } = createSimpleWrapper({ number: { isEven } }, { number })
+      const { vm } = await createSimpleWrapper({ number: { isEven } }, { number })
 
       vm.v.number.$model = 3
       await vm.$nextTick()
@@ -302,7 +303,7 @@ describe('useVuelidate', () => {
 
     it('should update the $dirty state to true when $model value changes', async () => {
       const number = ref(2)
-      const { vm } = createSimpleWrapper({ number: { isEven } }, { number })
+      const { vm } = await createSimpleWrapper({ number: { isEven } }, { number })
       shouldBePristineValidationObj(vm.v.number)
 
       vm.v.number.$model = 3
@@ -317,9 +318,9 @@ describe('useVuelidate', () => {
       expect(vm.v.number).toHaveProperty('$invalid', false)
     })
 
-    it('works with `reactive`', () => {
+    it('works with `reactive`', async () => {
       const { state, validations } = nestedReactiveObjectValidation()
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
       expect(vm.state.level0).toBe(0)
       expect(vm.v.level0.$model).toBe(0)
       vm.v.level0.$model = 5
@@ -333,9 +334,11 @@ describe('useVuelidate', () => {
     it('should collect child validations when they invalidate', async () => {
       const { state, parent } = nestedComponentValidation()
       const wrapper = mount(parent)
+      await nextTick()
+
       shouldBeInvalidValidationObject({ v: wrapper.vm.v, property: 'number', validatorName: 'isEven' })
       state.number.value = 3
-      await wrapper.vm.$nextTick()
+      await nextTick()
 
       expect(wrapper.vm.v.$errors).toEqual([{
         $message: '',
@@ -350,6 +353,7 @@ describe('useVuelidate', () => {
     it('should return false on $validate() if nested component validation is invalid', async () => {
       const { state, parent } = nestedComponentValidation()
       const wrapper = mount(parent)
+      await nextTick()
       shouldBeInvalidValidationObject({ v: wrapper.vm.v, property: 'number', validatorName: 'isEven' })
       // make the validation fail
       state.number.value = 3
@@ -363,6 +367,8 @@ describe('useVuelidate', () => {
     it('removes the child results if the child gets destroyed', async () => {
       const { childValidationRegisterName, parent, state } = nestedComponentValidation()
       const { vm } = mount(parent)
+      await nextTick()
+
       // make sure the validation object is clear
       shouldBeInvalidValidationObject({ v: vm.v, property: 'number', validatorName: 'isEven' })
       state.number.value = 3
@@ -381,6 +387,8 @@ describe('useVuelidate', () => {
     it('collects all child validation results, if parent `$scope` is not set', async () => {
       const { childValidationRegisterName, parent, state } = nestedComponentValidation({ childScope: 'child' })
       const { vm } = mount(parent)
+      await nextTick()
+
       shouldBeInvalidValidationObject({ v: vm.v, property: 'number', validatorName: 'isEven' })
       state.number.value = 3
       await vm.$nextTick()
@@ -392,6 +400,8 @@ describe('useVuelidate', () => {
     it('collects all child validation results, if both have the same `$scope`', async () => {
       const { childValidationRegisterName, parent, state } = nestedComponentValidation({ parentScope: 'sameScope', childScope: 'sameScope' })
       const { vm } = mount(parent)
+      await nextTick()
+
       shouldBeInvalidValidationObject({ v: vm.v, property: 'number', validatorName: 'isEven' })
       state.number.value = 3
       await vm.$nextTick()
@@ -403,6 +413,8 @@ describe('useVuelidate', () => {
     it('does not collect child validation results, if components have different `$scope`', async () => {
       const { childValidationRegisterName, parent, state } = nestedComponentValidation({ parentScope: 'parent', childScope: 'child' })
       const { vm } = mount(parent)
+      await nextTick()
+
       shouldBePristineValidationObj(vm.v)
       state.number.value = 3
       await vm.$nextTick()
@@ -414,9 +426,12 @@ describe('useVuelidate', () => {
     it('does not collect child validation, if child `$scope` is `COLLECT_NONE`', async () => {
       const { childValidationRegisterName, parent, state } = nestedComponentValidation({ childScope: CollectFlag.COLLECT_NONE })
       const { vm } = mount(parent)
+      await nextTick()
+
       shouldBePristineValidationObj(vm.v)
       state.number.value = 3
-      await vm.$nextTick()
+      await nextTick()
+
       const childState = vm.v.$getResultsForChild(childValidationRegisterName)
       expect(childState).toEqual(undefined)
       expect(vm.v.$errors).toEqual([])
@@ -425,6 +440,8 @@ describe('useVuelidate', () => {
     it('does not collect child validations, if parent `$scope` is `COLLECT_NONE`', async () => {
       const { childValidationRegisterName, parent, state } = nestedComponentValidation({ parentScope: CollectFlag.COLLECT_NONE })
       const { vm } = mount(parent)
+      await nextTick()
+
       shouldBePristineValidationObj(vm.v)
       state.number.value = 3
       await vm.$nextTick()
@@ -433,7 +450,7 @@ describe('useVuelidate', () => {
       expect(vm.v.$errors).toEqual([])
     })
 
-    it('stops the propagation of errors up the component chain', () => {
+    it('stops the propagation of errors up the component chain', async () => {
       const { state, validations } = simpleValidation()
       let $registerAs = 'componentC'
       const componentC = createSimpleComponent(() => useVuelidate(validations, state, { $registerAs }))
@@ -447,6 +464,8 @@ describe('useVuelidate', () => {
       }
       // mount the top most component
       const wrapper = mount(componentA)
+      await nextTick()
+
       // make sure it has no errors
       expect(wrapper.vm.v.$silentErrors).toHaveLength(0)
       // make sure the child component is not registered at all
@@ -464,9 +483,9 @@ describe('useVuelidate', () => {
   })
 
   describe('$error', () => {
-    it('returns `true` if both `$invalid` and $dirty` are true', () => {
+    it('returns `true` if both `$invalid` and $dirty` are true', async () => {
       const number = ref(1)
-      const { vm } = createSimpleWrapper({ number: { isEven } }, { number })
+      const { vm } = await createSimpleWrapper({ number: { isEven } }, { number })
       expect(vm.v.$invalid).toBe(true)
       expect(vm.v.$dirty).toBe(false)
       expect(vm.v.$error).toBe(false)
@@ -478,9 +497,9 @@ describe('useVuelidate', () => {
   })
 
   describe('$silentErrors', () => {
-    it('constructs an array of errors for invalid properties', () => {
+    it('constructs an array of errors for invalid properties', async () => {
       const { state, validations } = nestedReactiveObjectValidation()
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
       expect(vm.v.$silentErrors).toEqual(expect.any(Array))
       expect(vm.v.$silentErrors).toHaveLength(1)
       expect(vm.v.$silentErrors[0]).toMatchSnapshot()
@@ -488,20 +507,22 @@ describe('useVuelidate', () => {
   })
 
   describe('$errors', () => {
-    it('constructs an array of errors for invalid AND drity properties', () => {
+    it('constructs an array of errors for invalid AND drity properties', async () => {
       const { state, validations } = nestedReactiveObjectValidation()
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
       vm.v.$touch()
       expect(vm.v.$errors).toEqual(expect.any(Array))
       expect(vm.v.$errors).toHaveLength(1)
       expect(vm.v.$errors[0]).toMatchSnapshot()
     })
 
-    it('collects `$propertyPath` as of deeply nested properties', () => {
+    it('collects `$propertyPath` as of deeply nested properties', async () => {
       const { state, validations } = nestedReactiveObjectValidation()
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
 
       vm.v.level1.level2.child.$model = 3
+      await nextTick()
+
       expect(vm.v.$errors.find(error => error.$propertyPath === 'level1.level2.child')).toBeTruthy()
     })
 
@@ -522,6 +543,8 @@ describe('useVuelidate', () => {
     it('returns the validation results for a child component', async () => {
       const { childValidationRegisterName, parent, state } = nestedComponentValidation()
       const { vm } = mount(parent)
+      await nextTick()
+
       shouldBeInvalidValidationObject({ v: vm.v, property: 'number', validatorName: 'isEven' })
       state.number.value = 3
       await vm.$nextTick()
@@ -537,9 +560,9 @@ describe('useVuelidate', () => {
       })
     })
 
-    it('is only preset at the top level', () => {
+    it('is only preset at the top level', async () => {
       const { state, validations } = nestedReactiveObjectValidation()
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
       expect(vm.v).toHaveProperty('$getResultsForChild')
       expect(vm.v.level0).not.toHaveProperty('$getResultsForChild')
       expect(vm.v.level1).not.toHaveProperty('$getResultsForChild')
@@ -574,13 +597,13 @@ describe('useVuelidate', () => {
   describe('$validate', () => {
     it('returns the result of the validation', async () => {
       const { state, validations } = simpleValidation()
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
       expect(await vm.v.$validate()).toBe(false)
     })
 
     it('returns a Promise<Boolean>, that resolves instantly if `$pending === false`', async () => {
       const { state, validations } = simpleValidation()
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
       const promise = vm.v.$validate()
       expect(vm.v.$pending).toBe(false)
       await promise
@@ -589,15 +612,15 @@ describe('useVuelidate', () => {
 
     it('works with `lazy: true`', async () => {
       const { state, validations } = simpleValidation()
-      const { vm } = createSimpleWrapper(validations, state, { $lazy: true })
+      const { vm } = await createSimpleWrapper(validations, state, { $lazy: true })
       expect(await vm.v.$validate()).toBe(false)
       state.number.value = 2
       expect(await vm.v.$validate()).toBe(true)
     })
 
-    it('is only present at the top level', () => {
+    it('is only present at the top level', async () => {
       const { state, validations } = nestedReactiveObjectValidation()
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
 
       expect(vm.v).toHaveProperty('$validate', expect.any(Function))
       expect(vm.v.level0).not.toHaveProperty('$validate')
@@ -629,7 +652,7 @@ describe('useVuelidate', () => {
       // TODO: This is a breaking change, big one. Better let ppl know
       const isFive = jest.fn((v) => v === 5)
       const number = ref(0)
-      const { vm } = createSimpleWrapper({ number: { isFive } }, { number }, { $lazy: true })
+      const { vm } = await createSimpleWrapper({ number: { isFive } }, { number }, { $lazy: true })
       expect(isFive).toHaveBeenCalledTimes(0)
       number.value = 10
       expect(isFive).toHaveBeenCalledTimes(0)
@@ -654,61 +677,61 @@ describe('useVuelidate', () => {
     it('supports async validators via `$async: true` object syntax', async () => {
       jest.useFakeTimers()
       const { state, validations } = asyncValidation()
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
       vm.v.$touch()
-      await flushPromises()
+      await nextTick()
+      jest.advanceTimersByTime(6)
+      await nextTick()
       expect(vm.v.number.asyncIsEven.$pending).toBe(false)
       state.number.value = 6
+      await nextTick()
+
       expect(vm.v.number.asyncIsEven.$pending).toBe(true)
       expect(vm.v.number.$invalid).toBe(true)
-      await flushPromises()
+
+      jest.advanceTimersByTime(6)
+      await nextTick()
+
       expect(vm.v.number.asyncIsEven.$pending).toBe(false)
       expect(vm.v.number.$invalid).toBe(false)
       jest.useRealTimers()
     })
 
-    it('throws when passed an async validator directly', () => {
-      const asyncValidator = (v) => Promise.resolve(v)
-      const number = ref(0)
-      const component = {
-        template: '<div>Hello World</div>',
-        setup () {
-          const v = useVuelidate({ number: { asyncValidator } }, { number })
-          return { v }
-        }
-      }
-      const { vm } = mount(component)
-      // throws here, because we call the `$invalid` getter.
-      expect(() => vm.v.$touch).toThrowError()
-    })
-
-    // TODO: Fix this one
     it('allows multiple invocations of an async validator, the last one to resolve, sets the return value', async () => {
       // prepare async validator
       const validator = jest.fn().mockResolvedValue(true)
-      const asyncValidator = withAsync(validator)
       // prepare state
       const number = ref(0)
-      const { vm } = createSimpleWrapper({ number: { asyncValidator } }, { number })
+      const { vm } = await createSimpleWrapper({ number: { asyncValidator: validator } }, { number })
       // make sure the validator is armed
-      vm.v.$touch()
-      // assert its called once, for the dirty state change
       expect(validator).toHaveBeenCalledTimes(1)
+      vm.v.$touch()
+      await nextTick()
+      // assert its called once, for the dirty state change
+      expect(validator).toHaveBeenCalledTimes(2)
       // assert there is an error state
       expect(vm.v.number.asyncValidator.$invalid).toBe(true)
       expect(vm.v.number.$invalid).toBe(true)
+      expect(validator).toHaveBeenCalledTimes(2)
+
       // change it a few times
       number.value = 1
+      await nextTick()
       number.value = 2
+      await nextTick()
       validator.mockResolvedValueOnce(false)
       number.value = 3
       await flushPromises()
-      expect(validator).toHaveBeenCalledTimes(4)
+      expect(validator).toHaveBeenCalledTimes(5)
       // `invalid` is true, because the last invocation of the validator, is false
       expect(vm.v.number.asyncValidator.$invalid).toBe(true)
       number.value = 2
+      await nextTick()
+
       validator.mockResolvedValueOnce(true)
       number.value = 1
+      await nextTick()
+
       // await the last invocation to have been called
       await flushPromises()
       expect(validator).toHaveLastReturnedWith(Promise.resolve(true))
@@ -720,7 +743,7 @@ describe('useVuelidate', () => {
       it('allows passing a computed value as a validations object, with Refs', async () => {
         const { state, validations } = computedValidationsObjectWithRefs()
         const { number, conditional } = state
-        const { vm } = createSimpleWrapper(validations, state)
+        const { vm } = await createSimpleWrapper(validations, state)
         expect(vm.v.number).toHaveProperty('isOdd')
         vm.v.number.$touch()
         expect(vm.v.number.isOdd).toHaveProperty('$invalid', true)
@@ -737,19 +760,32 @@ describe('useVuelidate', () => {
         expect(vm.v.number.$invalid).toBe(false)
       })
 
-      it('allows passing a computed value as a validations object, with Reactive', () => {
+      it('allows passing a computed value as a validations object, with Reactive', async () => {
         const { state, validations } = computedValidationsObjectWithReactive()
-        const { vm } = createSimpleWrapper(validations, state)
+        const { vm } = await createSimpleWrapper(validations, state)
         expect(vm.v.number).toHaveProperty('isOdd')
         vm.v.number.$touch()
         expect(vm.v.number.isOdd).toHaveProperty('$invalid', true)
         state.number = 3
+        await nextTick()
+
         expect(vm.v.number.isOdd).toHaveProperty('$invalid', false)
+
+        state.number = 2
+        await nextTick()
+        expect(vm.v.number.isOdd).toHaveProperty('$invalid', true)
+
         // make sure the conditional is above the threshold
         state.conditional = 10
+        await nextTick()
+
         // assert it is no longer there
-        expect(vm.v.number).not.toHaveProperty('number')
+        expect(vm.v.number).not.toHaveProperty('isOdd')
         state.conditional = 3
+        await nextTick()
+        state.number = 3
+        await nextTick()
+
         expect(vm.v.number.$invalid).toBe(false)
       })
 
@@ -764,7 +800,7 @@ describe('useVuelidate', () => {
         const state = { number }
         const validations = { number: numberValidation }
 
-        const { vm } = createSimpleWrapper(validations, state)
+        const { vm } = await createSimpleWrapper(validations, state)
         shouldBePristineValidationObj(vm.v.number)
         vm.v.$touch()
         number.value = 3
@@ -790,7 +826,7 @@ describe('useVuelidate', () => {
       it('caches the `$dirty` state of a validator, if the validator gets removed and re-added', async () => {
         const { state, validations } = computedValidationsObjectWithRefs()
         const { number, conditional } = state
-        const { vm } = createSimpleWrapper(validations, { number })
+        const { vm } = await createSimpleWrapper(validations, { number })
         expect(vm.v.number).toHaveProperty('$dirty', false)
         vm.v.number.$touch()
         expect(vm.v.number).toHaveProperty('$dirty', true)
@@ -813,7 +849,7 @@ describe('useVuelidate', () => {
     it('trigger $dirty and $model reactions', async () => {
       const { state, validations } = nestedRefObjectValidation()
 
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
 
       expect(vm.v.level1.level2.child).toHaveProperty('$model', 2)
       expect(vm.v.level1.level2.child).toHaveProperty('$dirty', false)
@@ -839,7 +875,7 @@ describe('useVuelidate', () => {
     it('trigger $invalid reactions', async () => {
       const { state, validations } = nestedRefObjectValidation()
 
-      const { vm } = createSimpleWrapper(validations, state)
+      const { vm } = await createSimpleWrapper(validations, state)
 
       vm.v.level1.level2.child.$touch()
       expect(vm.v.level1.level2.child).toHaveProperty('$invalid', false)
@@ -853,6 +889,7 @@ describe('useVuelidate', () => {
           }
         }
       }
+      await nextTick()
 
       expect(vm.v.level1.level2.child).toHaveProperty('$invalid', true)
     })

--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -1,4 +1,4 @@
-import { computed, ref, h } from 'vue-demi'
+import { computed, ref, h, nextTick } from 'vue-demi'
 import { mount, flushPromises } from '../test-utils'
 import { isEven } from '../validators.fixture'
 
@@ -19,7 +19,6 @@ import {
   createSimpleComponent
 } from '../utils'
 import useVuelidate, { CollectFlag } from '../../../src'
-import { nextTick } from 'vue'
 
 describe('useVuelidate', () => {
   it('should have a `v` key defined if used', async () => {
@@ -258,7 +257,8 @@ describe('useVuelidate', () => {
 
     it('when used at root with plain object, should update the $dirty state', async () => {
       const number = ref(1)
-      const { vm } = createSimpleWrapper({ number: { isEven } }, { number }, { $autoDirty: true })
+      const { vm } = await createSimpleWrapper({ number: { isEven } }, { number }, { $autoDirty: true })
+
       shouldBeInvalidValidationObject({ v: vm.v.number, property: 'number', validatorName: 'isEven' })
 
       number.value = 3
@@ -275,7 +275,7 @@ describe('useVuelidate', () => {
 
     it('when used at root with reactive object, should update the $dirty state', async () => {
       const { state, validations } = nestedReactiveObjectValidation()
-      const { vm } = createSimpleWrapper(validations, state, { $autoDirty: true })
+      const { vm } = await createSimpleWrapper(validations, state, { $autoDirty: true })
       shouldBePristineValidationObj(vm.v.level0)
 
       state.level0 = 3

--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -774,6 +774,7 @@ describe('useVuelidate', () => {
         state.number = 2
         await nextTick()
         expect(vm.v.number.isOdd).toHaveProperty('$invalid', true)
+        expect(vm.v.number.$error).toBe(true)
 
         // make sure the conditional is above the threshold
         state.conditional = 10
@@ -783,6 +784,10 @@ describe('useVuelidate', () => {
         expect(vm.v.number).not.toHaveProperty('isOdd')
         state.conditional = 3
         await nextTick()
+        expect(vm.v.number).toHaveProperty('isOdd')
+        expect(vm.v.number.$invalid).toBe(true)
+        expect(vm.v.number.$error).toBe(true)
+        expect(vm.v.number).toHaveProperty('$dirty', true)
         state.number = 3
         await nextTick()
 

--- a/packages/vuelidate/test/unit/utils.js
+++ b/packages/vuelidate/test/unit/utils.js
@@ -1,4 +1,4 @@
-import { h, isRef } from 'vue-demi'
+import { h, nextTick } from 'vue-demi'
 import { useVuelidate } from '../../src'
 import { mount } from './test-utils'
 
@@ -32,9 +32,17 @@ export const createOldApiSimpleComponent = (validations, state, config) => ({
   }
 })
 
-export const createSimpleWrapper = (rules, state, config = {}) => mount(createSimpleComponent(() => useVuelidate(rules, state, config), state))
+export async function createSimpleWrapper (rules, state, config = {}) {
+  const wrapper = mount(createSimpleComponent(() => useVuelidate(rules, state, config), state))
+  await nextTick()
+  return wrapper
+}
 
-export const createOldApiSimpleWrapper = (rules, state, config = {}) => mount(createOldApiSimpleComponent(rules, state, config))
+export async function createOldApiSimpleWrapper (rules, state, config = {}) {
+  const wrapper = mount(createOldApiSimpleComponent(rules, state, config))
+  await nextTick()
+  return wrapper
+}
 
 export const shouldBePristineValidationObj = (v) => {
   expect(v).toHaveProperty('$error', false)

--- a/packages/vuelidate/test/unit/validations.fixture.js
+++ b/packages/vuelidate/test/unit/validations.fixture.js
@@ -73,7 +73,7 @@ export function computedValidationsObjectWithReactive () {
   })
   const validations = computed(() => {
     return state.conditional > 5
-      ? {}
+      ? { number: {} }
       : { number: { isOdd } }
   })
   return {

--- a/packages/vuelidate/test/unit/validators.fixture.js
+++ b/packages/vuelidate/test/unit/validators.fixture.js
@@ -1,11 +1,6 @@
-import { withAsync } from '@vuelidate/validators/src/common'
-
 export function toAsync (validator, time = 0) {
   return (value) => new Promise((resolve) =>
-    setTimeout(
-      resolve(validator(value)),
-      time
-    )
+    setTimeout(() => resolve(validator(value)), time)
   )
 }
 
@@ -14,5 +9,5 @@ export const isEven = (v) => {
 }
 export const isOdd = (v) => v % 2 === 1
 
-export const asyncIsEven = withAsync(toAsync(isEven, 5))
-export const asyncIsOdd = withAsync(toAsync(isOdd, 5))
+export const asyncIsEven = toAsync(isEven, 5)
+export const asyncIsOdd = toAsync(isOdd, 5)


### PR DESCRIPTION
## Summary

Make validators async by default. No need to wrap validators in `withAsync`, they can just return a Promise.