### PR TITLE
fix/replace $invalid with $valid

### DIFF
--- a/packages/validators/src/utils/common.js
+++ b/packages/validators/src/utils/common.js
@@ -44,7 +44,7 @@ export function isPromise (object) {
  * @return {boolean}
  */
 export function unwrapValidatorResponse (result) {
-  if (typeof result === 'object') return result.$invalid
+  if (typeof result === 'object') return result.$valid
   return result
 }
 

--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -36,7 +36,7 @@ type Component = ReturnType<typeof defineComponent>;
  */
 
 export interface ValidatorResponse {
-  $invalid: boolean
+  $valid: boolean
   [key: string]: any
 }
 


### PR DESCRIPTION
## Summary

Replaces forgotten occurrences of `$invalid` for rich validation responses with the new `$valid` property.