### PR TITLE
feat: add higher-order component helper for vuelidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "dependencies": {
-    "vue-demi": "^0.6.0"
+    "vue-demi": "^0.7.3"
   },
   "optionalDependencies": {
     "@vue/composition-api": "^1.0.0-rc.1"

--- a/packages/components/.browserslistrc
+++ b/packages/components/.browserslistrc
@@ -1,0 +1,6 @@
+# Browsers that we support
+
+last 2 versions
+> 1%
+maintained node versions
+not dead

--- a/packages/components/index.js
+++ b/packages/components/index.js
@@ -1,0 +1,1 @@
+export * from 'src'

--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -1,0 +1,7 @@
+const base = require('../../jest.base')
+
+module.exports = {
+  ...base,
+  name: 'Components',
+  displayName: 'Components'
+}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@vuelidate/components",
+  "version": "2.0.0-alpha.12",
+  "description": "Components for Vuelidate",
+  "main": "dist/index.js",
+  "types": "index.d.ts",
+  "module": "dist/index.esm.js",
+  "repository": "https://github.com/vuelidate/vuelidate",
+  "license": "MIT",
+  "scripts": {
+    "build": "bili src src/raw --format esm --format cjs",
+    "dev": "yarn build --watch",
+    "test:unit": "jest",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "vue-demi": "^0.7.3"
+  },
+  "devDependencies": {
+    "bili": "^4.8.1",
+    "flush-promises": "^1.0.2"
+  },
+  "sideEffects": [
+    "./src/utils/common.js"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "index.d.ts"
+  ]
+}

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,0 +1,26 @@
+import { h, toRefs } from 'vue-demi'
+import useVuelidate from '@vuelidate/core'
+
+export function withVuelidate (Component, options) {
+  return {
+    props: {
+      rules: {
+        type: Object,
+        default: () => ({})
+      },
+      modelValue: {
+        type: String,
+        default: ''
+      },
+      vConfig: {
+        type: Object,
+        default: () => ({})
+      }
+    },
+    setup (props, { attrs }) {
+      const { rules, modelValue, vConfig } = toRefs(props)
+      const v$ = useVuelidate({ modelValue: rules }, { modelValue: modelValue }, vConfig.value)
+      return () => h(Component, { ...props, ...attrs, errors: v$.value })
+    }
+  }
+}

--- a/packages/test-project/src/App.vue
+++ b/packages/test-project/src/App.vue
@@ -6,6 +6,7 @@
         <li><router-link to="/old-api">Old api</router-link></li>
         <li><router-link to="/nested-validations">Nested Validations</router-link></li>
         <li><router-link to="/nested-ref">Nested Ref</router-link></li>
+        <li><router-link to="/component-helper">Component Helper</router-link></li>
       </ul>
     </div>
     <router-view />

--- a/packages/test-project/src/components/ComponentHelper.vue
+++ b/packages/test-project/src/components/ComponentHelper.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="SimpleForm">
+    <TextInput
+      v-model="name"
+      label="Name"
+      :rules="{ required, minLength: minLength(3) }"
+      :v-config="{ $autoDirty: false }"
+    />
+    <button @click="validate">
+      Validate
+    </button>
+    <button @click="v$.$touch">
+      $touch
+    </button>
+    <button @click="v$.$reset">
+      $reset
+    </button>
+    <div style="background: rgba(219, 53, 53, 0.62); color: #ff9090; padding: 10px 15px">
+      <p
+        v-for="(error, index) of v$.$errors"
+        :key="index"
+        style="padding: 0; margin: 5px 0"
+      >
+        {{ error.$message }}
+      </p>
+    </div>
+    <pre>{{ v$ }}</pre>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue-demi'
+import useVuelidate from '@vuelidate/core'
+import { withVuelidate } from '@vuelidate/components'
+import { required, minLength } from '@vuelidate/validators'
+import _TextInput from './TextInput.vue'
+
+const TextInput = withVuelidate(_TextInput)
+
+export default {
+  name: 'ComponentHelper',
+  components: { TextInput },
+  setup () {
+    const name = ref('given name')
+
+    let v$ = useVuelidate()
+    return { name, v$, required, minLength }
+  },
+  methods: {
+    validate () {
+      this.v$.$validate({ silent: true }).then((result) => {
+        console.log('Result is', result)
+      })
+    }
+  }
+}
+</script>

--- a/packages/test-project/src/components/TextInput.vue
+++ b/packages/test-project/src/components/TextInput.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="form-input">
+    <label :for="label">{{ label }}</label>
+    <input
+      :id="label"
+      type="text"
+      :name="label"
+      :value="modelValue"
+      style="max-width: 300px"
+      @input="$emit('update:modelValue', $event.target.value)"
+    >
+    {{ errors }}
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    modelValue: {
+      type: String,
+      required: true
+    },
+    label: {
+      type: String,
+      required: true
+    },
+    errors: {
+      type: Object,
+      default: () => ({})
+    }
+  }
+}
+</script>
+
+<style>
+.form-input {
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/packages/test-project/src/routes.js
+++ b/packages/test-project/src/routes.js
@@ -2,6 +2,7 @@ import SimpleForm from './components/SimpleForm.vue'
 import NestedValidations from './components/NestedValidations.vue'
 import OldApiExample from './components/OldApiExample.vue'
 import ChainOfRefs from './components/ChainOfRefs.vue'
+import ComponentHelper from './components/ComponentHelper.vue'
 
 export const routes = [
   {
@@ -19,5 +20,9 @@ export const routes = [
   {
     path: '/nested-ref',
     component: ChainOfRefs
+  },
+  {
+    path: '/component-helper',
+    component: ComponentHelper
   }
 ]

--- a/packages/vuelidate/src/index.js
+++ b/packages/vuelidate/src/index.js
@@ -3,8 +3,8 @@ import { isFunction, unwrap, isProxy } from './utils'
 import { setValidations } from './core'
 import ResultsStorage from './storage'
 
-const VuelidateInjectChildResults = Symbol('vuelidate#injectChiildResults')
-const VuelidateRemoveChildResults = Symbol('vuelidate#removeChiildResults')
+const VuelidateInjectChildResults = 'vuelidate#injectChiildResults'
+const VuelidateRemoveChildResults = 'vuelidate#removeChiildResults'
 
 export const CollectFlag = {
   COLLECT_ALL: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12058,6 +12058,11 @@ vue-demi@^0.6.0:
   resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.6.0.tgz#e314282f704cb449119b9fd002cbbc0e39f591fe"
   integrity sha512-8GEJa0mHJpYJeGeq5fD1pJct2kfdl30PHfmL1NaJ97mgKPyKojlIRt/3inGBK4Y0ylCI6T5vOo3chwpqDOq/Hw==
 
+vue-demi@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.7.3.tgz#463188044d31d33985e67da51f315b447a1fed85"
+  integrity sha512-vrzM26H4CZCXBf/eu4T8nks6o7qgziYM52myk8bg+atw4qYqpeWJf5c82W8VdmgGfSIdh9ulOOe9+GeLc3Z/8A==
+
 vue-eslint-parser@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-7.1.0.tgz#9cdbcc823e656b087507a1911732b867ac101e83"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

A helper higher-order component that should make it possible to put validation rules inside the template easily instead of defining those in the wrapper component. Example usage in test-project:

```js
// _TextInput is an input component
const TextInput = withVuelidate(_TextInput)

// in template
<TextInput v-model="value" :rules="{ required }" />
```

**Sad part:** Works but there is an infinitely recursive thing going on which makes everything super slow.

**Other information:**
