### PR TITLE
feat: allow usage outside Vue components

### DIFF
--- a/packages/vuelidate/src/index.js
+++ b/packages/vuelidate/src/index.js
@@ -94,11 +94,13 @@ export function useVuelidate (validations, state, globalConfig = {}) {
   }
   let { $registerAs, $scope = CollectFlag.COLLECT_ALL, $stopPropagation } = globalConfig
 
-  const instance = getCurrentInstance()
+  let instance = getCurrentInstance()
 
-  const componentOptions = isVue3 ? instance.type : instance.proxy.$options
+  const componentOptions = instance
+    ? (isVue3 ? instance.type : instance.proxy.$options)
+    : {}
   // if there is no registration name, add one.
-  if (!$registerAs) {
+  if (!$registerAs && instance) {
     // NOTE:
     // ._uid // Vue 2.x Composition-API plugin
     // .uid // Vue 3.0
@@ -108,7 +110,13 @@ export function useVuelidate (validations, state, globalConfig = {}) {
   const validationResults = ref({})
   const resultsCache = new ResultsStorage()
 
-  const { childResults, sendValidationResultsToParent, removeValidationResultsFromParent } = nestedValidations({ $scope, $stopPropagation })
+  const {
+    childResults,
+    sendValidationResultsToParent,
+    removeValidationResultsFromParent
+  } = instance
+    ? nestedValidations({ $scope })
+    : { childResults: ref('') }
 
   // Options API
   if (!validations && componentOptions.validations) {
@@ -159,17 +167,19 @@ export function useVuelidate (validations, state, globalConfig = {}) {
         childResults,
         resultsCache,
         globalConfig,
-        instance: instance.proxy
+        instance: instance ? instance.proxy : {}
       })
     }, {
       immediate: true
     })
   }
 
-  // send all the data to the parent when the function is invoked inside setup.
-  sendValidationResultsToParent(validationResults, { $registerAs, $scope, $stopPropagation })
-  // before this component is destroyed, remove all the data from the parent.
-  onBeforeUnmount(() => removeValidationResultsFromParent($registerAs))
+  if (instance) {
+    // send all the data to the parent when the function is invoked inside setup.
+    sendValidationResultsToParent(validationResults, { $registerAs, $scope, $stopPropagation })
+    // before this component is destroyed, remove all the data from the parent.
+    onBeforeUnmount(() => removeValidationResultsFromParent($registerAs))
+  }
 
   // TODO: Change into reactive + watch
   return computed(() => {

--- a/packages/vuelidate/src/index.js
+++ b/packages/vuelidate/src/index.js
@@ -116,7 +116,7 @@ export function useVuelidate (validations, state, globalConfig = {}) {
     removeValidationResultsFromParent
   } = instance
     ? nestedValidations({ $scope })
-    : { childResults: ref('') }
+    : { childResults: ref({}) }
 
   // Options API
   if (!validations && componentOptions.validations) {

--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -17,7 +17,8 @@ import {
   shouldBePristineValidationObj,
   shouldBeInvalidValidationObject,
   shouldBeErroredValidationObject,
-  createSimpleComponent
+  createSimpleComponent,
+  shouldBeValidValidationObj
 } from '../utils'
 import { withMessage, withParams } from '@vuelidate/validators/src/common'
 import useVuelidate, { CollectFlag } from '../../../src'
@@ -1115,6 +1116,26 @@ describe('useVuelidate', () => {
       await nextTick()
 
       expect(vm.v.level1.level2.child).toHaveProperty('$invalid', true)
+    })
+  })
+
+  describe('Usage outside of Vue components', () => {
+    it('does not throw', () => {
+      const { validations, state } = simpleValidation()
+      expect(() => useVuelidate(validations, state)).not.toThrow()
+    })
+
+    it('returns a reactive Vuelidate state', async () => {
+      const { validations, state } = simpleValidation()
+      const v = useVuelidate(validations, state)
+      expect(v).toHaveProperty('value')
+      await nextTick()
+      shouldBeInvalidValidationObject({ v: v.value, property: 'number', validatorName: 'isEven' })
+      v.value.$touch()
+      shouldBeErroredValidationObject({ v: v.value, property: 'number', validatorName: 'isEven' })
+      v.value.number.$model = 6
+      await nextTick()
+      shouldBeValidValidationObj(v.value.number)
     })
   })
 

--- a/packages/vuelidate/test/unit/utils.js
+++ b/packages/vuelidate/test/unit/utils.js
@@ -46,7 +46,6 @@ export async function createOldApiSimpleWrapper (rules, state, config = {}) {
 
 export const shouldBePristineValidationObj = (v) => {
   expect(v).toHaveProperty('$error', false)
-  expect(v).toHaveProperty('$error', false)
   expect(v).toHaveProperty('$errors', [])
   expect(v).toHaveProperty('$silentErrors', [])
   expect(v).toHaveProperty('$invalid', false)
@@ -55,6 +54,14 @@ export const shouldBePristineValidationObj = (v) => {
   expect(v).toHaveProperty('$anyDirty', false)
   expect(v).toHaveProperty('$touch', expect.any(Function))
   expect(v).toHaveProperty('$reset', expect.any(Function))
+}
+
+export const shouldBeValidValidationObj = (v) => {
+  expect(v).toHaveProperty('$error', false)
+  expect(v).toHaveProperty('$errors', [])
+  expect(v).toHaveProperty('$silentErrors', [])
+  expect(v).toHaveProperty('$invalid', false)
+  expect(v).toHaveProperty('$pending', false)
 }
 
 export const shouldBeInvalidValidationObject = ({ v, property, propertyPath = property, validatorName }) => {


### PR DESCRIPTION
## Summary

Allows using Vuelidate outside of Vue Components. No breaking changes or API changes.

## Details

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)