### PR TITLE
fix: watch changes to arrays and objects deeply, closes #832

### DIFF
--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -138,7 +138,7 @@ function createAsyncResult (rule, model, $pending, $dirty, { $lazy }, $response,
           $response.value = error
           $invalid.value = true
         })
-    }, { immediate: true, deep: true }
+    }, { immediate: true, deep: typeof model === 'object' }
   )
 
   return { $invalid, $unwatch }

--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -138,7 +138,7 @@ function createAsyncResult (rule, model, $pending, $dirty, { $lazy }, $response,
           $response.value = error
           $invalid.value = true
         })
-    }, { immediate: true }
+    }, { immediate: true, deep: true }
   )
 
   return { $invalid, $unwatch }

--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -1,4 +1,4 @@
-import { computed, ref, h, nextTick, reactive } from 'vue-demi'
+import { computed, ref, h, nextTick, reactive, set } from 'vue-demi'
 import { mount, flushPromises } from '../test-utils'
 import { isEven } from '../validators.fixture'
 
@@ -1172,23 +1172,23 @@ describe('useVuelidate', () => {
       }
       const rules = {
         object: {
-          hasC: v => v.hasOwnProperty('b')
+          hasB: v => v.hasOwnProperty('b')
         }
       }
       const { vm } = await createSimpleWrapper(rules, state)
-      shouldBeInvalidValidationObject({ v: vm.v.object, validatorName: 'hasC', property: 'object' })
-      vm.v.object.$model.b = 'b'
+      shouldBeInvalidValidationObject({ v: vm.v.object, validatorName: 'hasB', property: 'object' })
+      set(state.object.value, 'b', 'b')
       await flushPromises()
       expect(state.object.value).toEqual({ a: 'a', b: 'b' })
       shouldBeValidValidationObj(vm.v.object)
       vm.v.object.$model = { c: 'c' }
       await flushPromises()
       expect(state.object.value).toEqual({ c: 'c' })
-      shouldBeErroredValidationObject({ v: vm.v.object, validatorName: 'hasC', property: 'object' })
+      shouldBeErroredValidationObject({ v: vm.v.object, validatorName: 'hasB', property: 'object' })
       vm.v.object.$model = {}
       await flushPromises()
       expect(state.object.value).toEqual({})
-      shouldBeErroredValidationObject({ v: vm.v.object, validatorName: 'hasC', property: 'object' })
+      shouldBeErroredValidationObject({ v: vm.v.object, validatorName: 'hasB', property: 'object' })
     })
 
     it('should track changes to reactive objects', async () => {
@@ -1202,7 +1202,7 @@ describe('useVuelidate', () => {
       }
       const { vm } = await createSimpleWrapper(rules, state)
       shouldBeInvalidValidationObject({ v: vm.v.object, validatorName: 'hasC', property: 'object' })
-      vm.v.object.$model.b = 'b'
+      set(vm.v.object.$model, 'b', 'b')
       await flushPromises()
       expect(state.object).toEqual({ a: 'a', b: 'b' })
       shouldBeValidValidationObj(vm.v.object)

--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -1,4 +1,4 @@
-import { computed, ref, h, nextTick } from 'vue-demi'
+import { computed, ref, h, nextTick, reactive } from 'vue-demi'
 import { mount, flushPromises } from '../test-utils'
 import { isEven } from '../validators.fixture'
 
@@ -1136,6 +1136,146 @@ describe('useVuelidate', () => {
       v.value.number.$model = 6
       await nextTick()
       shouldBeValidValidationObj(v.value.number)
+    })
+  })
+
+  describe('track collections', () => {
+    it('should track changes to ref array properties', async () => {
+      const state = {
+        array: ref([])
+      }
+      const rules = {
+        array: {
+          minLength: v => v.length > 1
+        }
+      }
+      const { vm } = await createSimpleWrapper(rules, state)
+      shouldBeInvalidValidationObject({ v: vm.v.array, validatorName: 'minLength', property: 'array' })
+      vm.v.array.$model.push('a')
+      vm.v.array.$model.push('b')
+      await flushPromises()
+      expect(state.array.value).toEqual(['a', 'b'])
+      shouldBeValidValidationObj(vm.v.array)
+      vm.v.array.$model = ['a']
+      await flushPromises()
+      expect(state.array.value).toEqual(['a'])
+      shouldBeErroredValidationObject({ v: vm.v.array, validatorName: 'minLength', property: 'array' })
+      vm.v.array.$model = []
+      await flushPromises()
+      expect(state.array.value).toEqual([])
+      shouldBeErroredValidationObject({ v: vm.v.array, validatorName: 'minLength', property: 'array' })
+    })
+
+    it('should track changes to ref objects', async () => {
+      const state = {
+        object: ref({ a: 'a' })
+      }
+      const rules = {
+        object: {
+          hasC: v => v.hasOwnProperty('b')
+        }
+      }
+      const { vm } = await createSimpleWrapper(rules, state)
+      shouldBeInvalidValidationObject({ v: vm.v.object, validatorName: 'hasC', property: 'object' })
+      vm.v.object.$model.b = 'b'
+      await flushPromises()
+      expect(state.object.value).toEqual({ a: 'a', b: 'b' })
+      shouldBeValidValidationObj(vm.v.object)
+      vm.v.object.$model = { c: 'c' }
+      await flushPromises()
+      expect(state.object.value).toEqual({ c: 'c' })
+      shouldBeErroredValidationObject({ v: vm.v.object, validatorName: 'hasC', property: 'object' })
+      vm.v.object.$model = {}
+      await flushPromises()
+      expect(state.object.value).toEqual({})
+      shouldBeErroredValidationObject({ v: vm.v.object, validatorName: 'hasC', property: 'object' })
+    })
+
+    it('should track changes to reactive objects', async () => {
+      const state = reactive({
+        object: { a: 'a' }
+      })
+      const rules = {
+        object: {
+          hasC: v => v.hasOwnProperty('b')
+        }
+      }
+      const { vm } = await createSimpleWrapper(rules, state)
+      shouldBeInvalidValidationObject({ v: vm.v.object, validatorName: 'hasC', property: 'object' })
+      vm.v.object.$model.b = 'b'
+      await flushPromises()
+      expect(state.object).toEqual({ a: 'a', b: 'b' })
+      shouldBeValidValidationObj(vm.v.object)
+      vm.v.object.$model = { c: 'c' }
+      await flushPromises()
+      expect(state.object).toEqual({ c: 'c' })
+      shouldBeErroredValidationObject({ v: vm.v.object, validatorName: 'hasC', property: 'object' })
+      vm.v.object.$model = {}
+      await flushPromises()
+      expect(state.object).toEqual({})
+      shouldBeErroredValidationObject({ v: vm.v.object, validatorName: 'hasC', property: 'object' })
+    })
+
+    it('should track changes to reactive array properties', async () => {
+      const state = reactive({
+        array: []
+      })
+      const rules = {
+        array: {
+          minLength: v => v.length > 1
+        }
+      }
+      const { vm } = await createSimpleWrapper(rules, state)
+      shouldBeInvalidValidationObject({ v: vm.v.array, validatorName: 'minLength', property: 'array' })
+      vm.v.array.$model.push('a')
+      vm.v.array.$model.push('b')
+      await flushPromises()
+      expect(state.array).toEqual(['a', 'b'])
+      shouldBeValidValidationObj(vm.v.array)
+      vm.v.array.$model = ['a']
+      await flushPromises()
+      expect(state.array).toEqual(['a'])
+      shouldBeErroredValidationObject({ v: vm.v.array, validatorName: 'minLength', property: 'array' })
+      vm.v.array.$model = []
+      await flushPromises()
+      expect(state.array).toEqual([])
+      shouldBeErroredValidationObject({ v: vm.v.array, validatorName: 'minLength', property: 'array' })
+    })
+
+    it('should not call sibling validators, more times than necessary', async () => {
+      const state = reactive({
+        parent: {
+          child1: 'foo',
+          child2: 'bar'
+        }
+      })
+      const isFoo = jest.fn(v => v === 'foo')
+      const isBar = jest.fn(v => v === 'bar')
+
+      const rules = {
+        parent: {
+          child1: { isFoo },
+          child2: { isBar }
+        }
+      }
+      const { vm } = await createSimpleWrapper(rules, state)
+      expect(isFoo).toHaveBeenCalledTimes(1)
+      expect(isBar).toHaveBeenCalledTimes(1)
+
+      state.parent.child1 = 'bar'
+
+      await flushPromises()
+      expect(isFoo).toHaveBeenCalledTimes(2)
+      expect(isBar).toHaveBeenCalledTimes(1)
+
+      state.parent.child2 = 'foo'
+
+      await flushPromises()
+      expect(isFoo).toHaveBeenCalledTimes(2)
+      expect(isBar).toHaveBeenCalledTimes(2)
+
+      shouldBeInvalidValidationObject({ v: vm.v.parent.child1, validatorName: 'isFoo', property: 'child1', propertyPath: 'parent.child1' })
+      shouldBeInvalidValidationObject({ v: vm.v.parent.child2, validatorName: 'isBar', property: 'child2', propertyPath: 'parent.child2' })
     })
   })
 


### PR DESCRIPTION
## Summary

Arrays and objects were not being deeply watched, so this should fix that. closes #832 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
