### PR TITLE
feat(core): add external validations support

### DIFF
--- a/packages/docs/src/advanced_usage.md
+++ b/packages/docs/src/advanced_usage.md
@@ -224,10 +224,10 @@ export default {
 }
 ```
 
-:::tip You can pass validation configs as a single parameter to `useVuelidate`
-
+:::tip
+**Note:** You can pass validation configs as a single parameter to `useVuelidate`
 - [Passing a single parameter to useVuelidate](#passing-a-single-parameter-to-usevuelidate)
-  :::
+:::
 
 ## Returning extra data from validators
 
@@ -331,19 +331,19 @@ export default {
 
 ## Providing external validations, server side validation
 
-To provide validation messages from an external source, like from a server side validation response, you can use the `externalResults` feature. Each
-property in the validated state can have one or array of messages. This works with both Composition API and Options API.
+To provide validation messages from an external source, like from a server side validation response, you can use the `$externalResults` functionality.
+Each property in the validated state can have a corresponding string or array of strings as response message. This works with both Composition API and
+Options API.
 
 ### External results with Composition API
 
-When using the Composition API, you can pass a `reactive` object, or a `ref` object, to the `$externalResults` global config.
+When using the Composition API, you can pass a `reactive` or `ref` object, to the `$externalResults` global config.
 
 ```js
 // inside setup
 const state = reactive({ foo: '' });
-const $externalResults = reactive({})
-// you can also use a ref
-// const $externalResults = ref({})
+const $externalResults = ref({}) // works with reactive({}) too.
+
 const rules = { foo: { someValidation } }
 const v = useVuelidate(rules, state, { $externalResults })
 
@@ -351,12 +351,13 @@ const v = useVuelidate(rules, state, { $externalResults })
 async function validate () {
   // check if everything is valid
   if (!await v.value.$validate()) return
+  await doAsyncStuff()
   // do server validation, and assume we have these errors
   const errors = {
     foo: ['Error one', 'Error Two']
   }
-  // merge the errors into the external results object
-  Object.assign($externalResults, errors)
+  // add the errors into the external results object
+  $externalResults.value = errors // if using a `reactive` object instead, use `Object.assign($externalResults, errors)`
 }
 
 return { v, validate }
@@ -377,14 +378,18 @@ async function validate () {
 
 ### External results with Options API
 
-When using the Options API, you just need to assign the results to the `vuelidateExternalResults` data property.
+When using the Options API, you just need to define a `vuelidateExternalResults` data property, and assign the errors to it.
+
+It is a good practice to pre-define your external results keys, to match your form structure, otherwise Vue may have a hard time tracking changes.
 
 ```js
 export default {
   data () {
     return {
       foo: '',
-      vuelidateExternalResults: {}
+      vuelidateExternalResults: {
+        foo: []
+      }
     }
   },
   validations () {
@@ -406,8 +411,8 @@ export default {
 To clear out the external results, you can again, use the `$clearExternalResults()` method
 
 ```js
-async validate () {
-  this.$clearExternalResults()
+async function validate() {
+  this.$v.$clearExternalResults()
   // perform validations
   const result = await this.runAsyncValidators()
 }

--- a/packages/docs/src/api/methods.md
+++ b/packages/docs/src/api/methods.md
@@ -30,3 +30,9 @@
 * **Usage:**
 
   Resets the `$dirty` state on all nested properties of a form.
+
+## $clearExternalResults
+
+* **Usage:**
+
+  Clears the `$externalResults` state back to an empty object.

--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -104,6 +104,7 @@ type BaseValidation <
   readonly $error: boolean
   readonly $errors: ErrorObject[]
   readonly $silentErrors: ErrorObject[]
+  readonly $externalResults: ({ $validator: '$externalResults', $response: null, $pending: false, $params: {} } & ErrorObject)[]
   readonly $invalid: boolean
   readonly $anyDirty: boolean
   readonly $pending: boolean
@@ -128,6 +129,7 @@ type NestedValidations <Vargs extends ValidationArgs = ValidationArgs, T = unkno
 interface ChildValidations {
   readonly $validate: () => Promise<boolean>
   readonly $getResultsForChild: (key: string) => (BaseValidation & ChildValidations) | undefined
+  readonly $clearExternalResults: () => void
 }
 
 export type Validation <Vargs extends ValidationArgs = ValidationArgs, T = unknown> =
@@ -158,12 +160,17 @@ type ExtractState <Vargs extends ValidationArgs> = Vargs extends ValidationRuleC
 
 type ToRefs <T> = { [K in keyof T]: Ref<T[K]> };
 
+interface ServerErrors {
+  [key: string]: string | string[] | ServerErrors
+}
+
 interface GlobalConfig {
   $registerAs?: string
   $scope?: string | number | symbol | boolean
   $stopPropagation?: boolean
   $autoDirty?: boolean
-  $lazy?: boolean
+  $lazy?: boolean,
+  $externalResults: ServerErrors
 }
 
 export function useVuelidate(globalConfig?: GlobalConfig): Ref<Validation>;

--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -534,6 +534,9 @@ export function setValidations ({
     })
     : state
 
+  // cache the external results, so we can revert back to them
+  const cachedExternalResults = { ...(unwrap(externalResults) || {}) }
+
   const nestedExternalResults = computed(() => {
     const results = unwrap(externalResults)
     if (!key) return results
@@ -615,13 +618,19 @@ export function setValidations ({
   }
 
   function $clearExternalResults () {
-    Object.keys(unwrap(externalResults)).forEach((key) => {
-      if (isRef(externalResults)) {
-        del(externalResults.value, key)
+    if (isRef(externalResults)) {
+      externalResults.value = cachedExternalResults
+    } else {
+      // if the external results state was empty, we need to delete every property, one by one
+      if (Object.keys(cachedExternalResults).length === 0) {
+        Object.keys(externalResults).forEach((k) => {
+          delete externalResults[k]
+        })
       } else {
-        del(externalResults, key)
+        // state was not empty, so we just assign it back into the current state
+        Object.assign(externalResults, cachedExternalResults)
       }
-    })
+    }
   }
 
   return reactive({

--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -1,5 +1,5 @@
 import { isFunction, unwrap, unwrapObj } from './utils'
-import { computed, isRef, reactive, ref, watch, nextTick } from 'vue-demi'
+import { computed, isRef, reactive, ref, watch, nextTick, del } from 'vue-demi'
 
 let ROOT_PATH = '__root'
 
@@ -614,6 +614,16 @@ export function setValidations ({
     return (childResults.value || {})[key]
   }
 
+  function $clearExternalResults () {
+    Object.keys(unwrap(externalResults)).forEach((key) => {
+      if (isRef(externalResults)) {
+        del(externalResults.value, key)
+      } else {
+        del(externalResults, key)
+      }
+    })
+  }
+
   return reactive({
     ...results,
     // NOTE: The order here is very important, since we want to override
@@ -633,7 +643,8 @@ export function setValidations ({
     // if there are no child results, we are inside a nested property
     ...(childResults && {
       $getResultsForChild,
-      $validate
+      $validate,
+      $clearExternalResults
     }),
     // add each nested property's state
     ...nestedResults

--- a/packages/vuelidate/src/index.js
+++ b/packages/vuelidate/src/index.js
@@ -74,6 +74,7 @@ function nestedValidations ({ $scope }) {
  * @property {String} [$registerAs] - Config Object
  * @property {String | Number | Symbol} [$scope] - A scope to limit child component registration
  * @property {Boolean} [$stopPropagation] - Tells a Vue component to stop sending it's results up to the parent
+ * @property {Ref<Object>} [$externalResults] - External error messages, like from server validation.
  */
 
 /**
@@ -92,7 +93,7 @@ export function useVuelidate (validations, state, globalConfig = {}) {
     validations = undefined
     state = undefined
   }
-  let { $registerAs, $scope = CollectFlag.COLLECT_ALL, $stopPropagation } = globalConfig
+  let { $registerAs, $scope = CollectFlag.COLLECT_ALL, $stopPropagation, $externalResults } = globalConfig
 
   const instance = getCurrentInstance()
 
@@ -140,7 +141,8 @@ export function useVuelidate (validations, state, globalConfig = {}) {
             childResults,
             resultsCache,
             globalConfig,
-            instance: instance.proxy
+            instance: instance.proxy,
+            externalResults: instance.proxy.vuelidateExternalResults
           })
         }, { immediate: true })
     })
@@ -159,7 +161,8 @@ export function useVuelidate (validations, state, globalConfig = {}) {
         childResults,
         resultsCache,
         globalConfig,
-        instance: instance.proxy
+        instance: instance.proxy,
+        externalResults: $externalResults
       })
     }, {
       immediate: true

--- a/packages/vuelidate/src/utils.js
+++ b/packages/vuelidate/src/utils.js
@@ -1,10 +1,6 @@
-import { isRef, computed, ref, isReactive, isReadonly } from 'vue-demi'
+import { isRef, computed, ref, isReactive, isReadonly, unref as unwrap } from 'vue-demi'
 
-export function unwrap (val) {
-  return isRef(val)
-    ? val.value
-    : val
-}
+export { unwrap }
 
 export function unwrapObj (obj, ignoreKeys = []) {
   return Object.keys(obj).reduce((o, k) => {

--- a/packages/vuelidate/test/unit/specs/optionsApi.spec.js
+++ b/packages/vuelidate/test/unit/specs/optionsApi.spec.js
@@ -284,6 +284,40 @@ describe('OptionsAPI validations', () => {
     })
   })
 
+  it('saves external results', async () => {
+    const validation = {
+      number: { isEven }
+    }
+    const { vm } = await createOldApiSimpleWrapper(validation, { number: 1, vuelidateExternalResults: { number: '' } })
+
+    vm.v.$touch()
+    expect(vm.vuelidateExternalResults).toEqual({ number: '' })
+
+    expect(vm.v).toHaveProperty('number', expect.any(Object))
+    expect(vm.v.number.$externalResults).toEqual([])
+    // set an external validation result
+    vm.vuelidateExternalResults.number = ['foo']
+    // assert
+    const externalErrorObject = {
+      '$message': 'foo',
+      '$property': 'number',
+      '$propertyPath': 'number',
+      '$validator': '$externalResults'
+    }
+    expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
+    expect(vm.v.number.$error).toBe(true)
+    expect(vm.v.number.$silentErrors).toHaveLength(2)
+    expect(vm.v.number.$silentErrors).toContainEqual(externalErrorObject)
+    vm.v.number.$model = 2
+    await nextTick()
+    expect(vm.v.number.$error).toBe(true)
+    expect(vm.v.number.$silentErrors).toHaveLength(1)
+    expect(vm.v.number.$silentErrors).toEqual([externalErrorObject])
+    vm.vuelidateExternalResults.number = []
+    expect(vm.v.number.$error).toBe(false)
+    expect(vm.v.number.$silentErrors).toEqual([])
+  })
+
   describe('deep changes in state', () => {
     it('trigger $dirty and $model reactions', async () => {
       const { state, validations } = nestedRefObjectValidation()

--- a/packages/vuelidate/test/unit/specs/optionsApi.spec.js
+++ b/packages/vuelidate/test/unit/specs/optionsApi.spec.js
@@ -285,7 +285,7 @@ describe('OptionsAPI validations', () => {
   })
 
   describe('external results', () => {
-    it('saves external results', async () => {
+    it('saves external results, by changing individual properties', async () => {
       const validation = {
         number: { isEven }
       }
@@ -319,14 +319,15 @@ describe('OptionsAPI validations', () => {
       expect(vm.v.number.$silentErrors).toEqual([])
     })
 
-    it('works with replacing the entire state', async () => {
+    it('works by replacing the entire external state, with pre-definition', async () => {
       const validation = {
         number: { isEven }
       }
-      const { vm } = await createOldApiSimpleWrapper(validation, { number: 1, vuelidateExternalResults: {} })
+      const vuelidateExternalResults = { number: '' }
+      const { vm } = await createOldApiSimpleWrapper(validation, { number: 1, vuelidateExternalResults })
 
       vm.v.$touch()
-      expect(vm.vuelidateExternalResults).toEqual({})
+      expect(vm.vuelidateExternalResults).toEqual({ number: '' })
 
       expect(vm.v).toHaveProperty('number', expect.any(Object))
       expect(vm.v.number.$externalResults).toEqual([])
@@ -349,8 +350,18 @@ describe('OptionsAPI validations', () => {
       expect(vm.v.number.$silentErrors).toHaveLength(1)
       expect(vm.v.number.$silentErrors).toEqual([externalErrorObject])
       vm.v.$clearExternalResults()
+      expect(vm.vuelidateExternalResults).toEqual(vuelidateExternalResults)
+      expect(vm.v.number.$externalResults).toEqual([])
       expect(vm.v.number.$error).toBe(false)
       expect(vm.v.number.$silentErrors).toEqual([])
+      // trigger again
+      Object.assign(vm.vuelidateExternalResults, { number: ['bar'] })
+      expect(vm.v.number.$externalResults).toEqual([{
+        $message: 'bar',
+        $property: 'number',
+        $propertyPath: 'number',
+        $validator: '$externalResults'
+      }])
     })
   })
 

--- a/packages/vuelidate/test/unit/specs/optionsApi.spec.js
+++ b/packages/vuelidate/test/unit/specs/optionsApi.spec.js
@@ -15,7 +15,6 @@ import {
 } from '../validations.fixture'
 import { flushPromises, mount } from '../test-utils'
 import withAsync from '@vuelidate/validators/src/utils/withAsync'
-import { toRef } from '@vue/composition-api'
 
 describe('OptionsAPI validations', () => {
   it('should have a `v` key defined if used', async () => {
@@ -329,10 +328,14 @@ describe('OptionsAPI validations', () => {
       vm.vuelidateExternalResults.number = ['foo']
       // assert
       const externalErrorObject = {
-        '$message': 'foo',
-        '$property': 'number',
-        '$propertyPath': 'number',
-        '$validator': '$externalResults'
+        $message: 'foo',
+        $params: {},
+        $pending: false,
+        $property: 'number',
+        $propertyPath: 'number',
+        $response: null,
+        $uid: 'number-0',
+        $validator: '$externalResults'
       }
       expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
       expect(vm.v.number.$error).toBe(true)
@@ -364,10 +367,14 @@ describe('OptionsAPI validations', () => {
       Object.assign(vm.vuelidateExternalResults, { number: ['foo'] })
       // assert
       const externalErrorObject = {
-        '$message': 'foo',
-        '$property': 'number',
-        '$propertyPath': 'number',
-        '$validator': '$externalResults'
+        $message: 'foo',
+        $params: {},
+        $pending: false,
+        $property: 'number',
+        $propertyPath: 'number',
+        $response: null,
+        $uid: 'number-0',
+        $validator: '$externalResults'
       }
       expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
       expect(vm.v.number.$error).toBe(true)
@@ -387,8 +394,12 @@ describe('OptionsAPI validations', () => {
       Object.assign(vm.vuelidateExternalResults, { number: ['bar'] })
       expect(vm.v.number.$externalResults).toEqual([{
         $message: 'bar',
+        $params: {},
+        $pending: false,
         $property: 'number',
         $propertyPath: 'number',
+        $response: null,
+        $uid: 'number-0',
         $validator: '$externalResults'
       }])
     })

--- a/packages/vuelidate/test/unit/specs/optionsApi.spec.js
+++ b/packages/vuelidate/test/unit/specs/optionsApi.spec.js
@@ -284,38 +284,74 @@ describe('OptionsAPI validations', () => {
     })
   })
 
-  it('saves external results', async () => {
-    const validation = {
-      number: { isEven }
-    }
-    const { vm } = await createOldApiSimpleWrapper(validation, { number: 1, vuelidateExternalResults: { number: '' } })
+  describe('external results', () => {
+    it('saves external results', async () => {
+      const validation = {
+        number: { isEven }
+      }
+      const { vm } = await createOldApiSimpleWrapper(validation, { number: 1, vuelidateExternalResults: { number: '' } })
 
-    vm.v.$touch()
-    expect(vm.vuelidateExternalResults).toEqual({ number: '' })
+      vm.v.$touch()
+      expect(vm.vuelidateExternalResults).toEqual({ number: '' })
 
-    expect(vm.v).toHaveProperty('number', expect.any(Object))
-    expect(vm.v.number.$externalResults).toEqual([])
-    // set an external validation result
-    vm.vuelidateExternalResults.number = ['foo']
-    // assert
-    const externalErrorObject = {
-      '$message': 'foo',
-      '$property': 'number',
-      '$propertyPath': 'number',
-      '$validator': '$externalResults'
-    }
-    expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
-    expect(vm.v.number.$error).toBe(true)
-    expect(vm.v.number.$silentErrors).toHaveLength(2)
-    expect(vm.v.number.$silentErrors).toContainEqual(externalErrorObject)
-    vm.v.number.$model = 2
-    await nextTick()
-    expect(vm.v.number.$error).toBe(true)
-    expect(vm.v.number.$silentErrors).toHaveLength(1)
-    expect(vm.v.number.$silentErrors).toEqual([externalErrorObject])
-    vm.vuelidateExternalResults.number = []
-    expect(vm.v.number.$error).toBe(false)
-    expect(vm.v.number.$silentErrors).toEqual([])
+      expect(vm.v).toHaveProperty('number', expect.any(Object))
+      expect(vm.v.number.$externalResults).toEqual([])
+      // set an external validation result
+      vm.vuelidateExternalResults.number = ['foo']
+      // assert
+      const externalErrorObject = {
+        '$message': 'foo',
+        '$property': 'number',
+        '$propertyPath': 'number',
+        '$validator': '$externalResults'
+      }
+      expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
+      expect(vm.v.number.$error).toBe(true)
+      expect(vm.v.number.$silentErrors).toHaveLength(2)
+      expect(vm.v.number.$silentErrors).toContainEqual(externalErrorObject)
+      vm.v.number.$model = 2
+      await nextTick()
+      expect(vm.v.number.$error).toBe(true)
+      expect(vm.v.number.$silentErrors).toHaveLength(1)
+      expect(vm.v.number.$silentErrors).toEqual([externalErrorObject])
+      vm.vuelidateExternalResults.number = []
+      expect(vm.v.number.$error).toBe(false)
+      expect(vm.v.number.$silentErrors).toEqual([])
+    })
+
+    it('works with replacing the entire state', async () => {
+      const validation = {
+        number: { isEven }
+      }
+      const { vm } = await createOldApiSimpleWrapper(validation, { number: 1, vuelidateExternalResults: {} })
+
+      vm.v.$touch()
+      expect(vm.vuelidateExternalResults).toEqual({})
+
+      expect(vm.v).toHaveProperty('number', expect.any(Object))
+      expect(vm.v.number.$externalResults).toEqual([])
+      // set an external validation result
+      Object.assign(vm.vuelidateExternalResults, { number: ['foo'] })
+      // assert
+      const externalErrorObject = {
+        '$message': 'foo',
+        '$property': 'number',
+        '$propertyPath': 'number',
+        '$validator': '$externalResults'
+      }
+      expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
+      expect(vm.v.number.$error).toBe(true)
+      expect(vm.v.number.$silentErrors).toHaveLength(2)
+      expect(vm.v.number.$silentErrors).toContainEqual(externalErrorObject)
+      vm.v.number.$model = 2
+      await nextTick()
+      expect(vm.v.number.$error).toBe(true)
+      expect(vm.v.number.$silentErrors).toHaveLength(1)
+      expect(vm.v.number.$silentErrors).toEqual([externalErrorObject])
+      vm.v.$clearExternalResults()
+      expect(vm.v.number.$error).toBe(false)
+      expect(vm.v.number.$silentErrors).toEqual([])
+    })
   })
 
   describe('deep changes in state', () => {

--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -1347,10 +1347,14 @@ describe('useVuelidate', () => {
         number: 'External Error'
       }
       let externalErrorObject = {
-        '$message': 'External Error',
-        '$property': 'number',
-        '$propertyPath': 'number',
-        '$validator': '$externalResults'
+        $message: 'External Error',
+        $params: {},
+        $pending: false,
+        $property: 'number',
+        $propertyPath: 'number',
+        $response: null,
+        $uid: 'number-0',
+        $validator: '$externalResults'
       }
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
@@ -1376,16 +1380,24 @@ describe('useVuelidate', () => {
         number: ['External Error 1', 'External Error 2']
       }
       let externalErrorObjectOne = {
-        '$message': 'External Error 1',
-        '$property': 'number',
-        '$propertyPath': 'number',
-        '$validator': '$externalResults'
+        $message: 'External Error 1',
+        $property: 'number',
+        $propertyPath: 'number',
+        $validator: '$externalResults',
+        $params: {},
+        $pending: false,
+        $response: null,
+        $uid: 'number-0'
       }
       let externalErrorObjectTwo = {
-        '$message': 'External Error 2',
-        '$property': 'number',
-        '$propertyPath': 'number',
-        '$validator': '$externalResults'
+        $message: 'External Error 2',
+        $property: 'number',
+        $propertyPath: 'number',
+        $validator: '$externalResults',
+        $params: {},
+        $pending: false,
+        $response: null,
+        $uid: 'number-1'
       }
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$externalResults).toEqual([externalErrorObjectOne, externalErrorObjectTwo])
@@ -1402,7 +1414,7 @@ describe('useVuelidate', () => {
       expect(vm.v.number.$error).toBe(false)
     })
 
-    it('accepts a reactive object, with pre-definition', async () => {
+    it('accepts a reactive object, with pre-defined properties', async () => {
       const $externalResults = reactive({ number: '' })
       const { state, validations } = simpleValidation()
       const { vm } = await createSimpleWrapper(validations, state, { $externalResults })
@@ -1411,11 +1423,16 @@ describe('useVuelidate', () => {
       $externalResults.number = 'External Error'
 
       let externalErrorObject = {
-        '$message': 'External Error',
-        '$property': 'number',
-        '$propertyPath': 'number',
-        '$validator': '$externalResults'
+        $message: 'External Error',
+        $property: 'number',
+        $propertyPath: 'number',
+        $validator: '$externalResults',
+        $params: {},
+        $pending: false,
+        $response: null,
+        $uid: 'number-0'
       }
+
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
       expect(vm.v.number.$silentErrors).toHaveLength(2)
@@ -1431,8 +1448,52 @@ describe('useVuelidate', () => {
       expect(vm.v.number.$error).toBe(false)
       expect(vm.v.number.$externalResults).toEqual([])
       expect(vm.v.number.$silentErrors).toEqual([])
+
+      // test what happens after we clear
+      $externalResults.number = 'External Error'
+
+      expect(vm.v.number.$error).toBe(true)
+      expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
+      expect(vm.v.number.$silentErrors).toHaveLength(1)
+      expect(vm.v.number.$silentErrors).toEqual([externalErrorObject])
     })
 
+    it('accepts a ref object, with deeply nested validations', async () => {
+      const $externalResults = ref({})
+      const { state, validations } = nestedRefObjectValidation()
+      const { vm } = await createSimpleWrapper(validations, state, { $externalResults })
+      vm.v.$touch()
+      $externalResults.value = {
+        level1: {
+          child: ['External Error 1', 'External Error 2']
+        }
+      }
+      const externalErrorObjectOne = {
+        $message: 'External Error 1',
+        $property: 'child',
+        $propertyPath: 'level1.child',
+        $validator: '$externalResults',
+        $params: {},
+        $pending: false,
+        $response: null,
+        $uid: 'level1.child-0'
+      }
+      const externalErrorObjectTwo = {
+        $message: 'External Error 2',
+        $property: 'child',
+        $propertyPath: 'level1.child',
+        $validator: '$externalResults',
+        $params: {},
+        $pending: false,
+        $response: null,
+        $uid: 'level1.child-1'
+      }
+
+      expect(vm.v.$errors).toHaveLength(3)
+      expect(vm.v.$errors).toEqual(expect.arrayContaining([externalErrorObjectOne, externalErrorObjectTwo]))
+    })
+
+    // reactive does not work in Vue 2, without pre-defining your keys.
     ifVue3('accepts a reactive object, without pre-definition', async () => {
       const $externalResults = reactive({})
       const { state, validations } = simpleValidation()
@@ -1442,10 +1503,14 @@ describe('useVuelidate', () => {
       $externalResults.number = 'External Error'
 
       let externalErrorObject = {
-        '$message': 'External Error',
-        '$property': 'number',
-        '$propertyPath': 'number',
-        '$validator': '$externalResults'
+        $message: 'External Error',
+        $property: 'number',
+        $propertyPath: 'number',
+        $validator: '$externalResults',
+        $params: {},
+        $pending: false,
+        $response: null,
+        $uid: 'number-0'
       }
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$externalResults).toEqual([externalErrorObject])

--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -1306,7 +1306,7 @@ describe('useVuelidate', () => {
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$silentErrors).toHaveLength(1)
       expect(vm.v.number.$silentErrors).toEqual([externalErrorObject])
-      $externalResults.value = {}
+      vm.v.$clearExternalResults()
       expect(vm.v.number.$error).toBe(false)
     })
 
@@ -1342,7 +1342,7 @@ describe('useVuelidate', () => {
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$silentErrors).toHaveLength(2)
       expect(vm.v.number.$silentErrors).toEqual([externalErrorObjectOne, externalErrorObjectTwo])
-      $externalResults.value = {}
+      vm.v.$clearExternalResults()
       expect(vm.v.number.$error).toBe(false)
     })
 
@@ -1370,8 +1370,10 @@ describe('useVuelidate', () => {
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$silentErrors).toHaveLength(1)
       expect(vm.v.number.$silentErrors).toEqual([externalErrorObject])
-      $externalResults.number = undefined
+      // assert it clears out results
+      vm.v.$clearExternalResults()
       expect(vm.v.number.$error).toBe(false)
+      expect(vm.v.number.$externalResults).toEqual([])
       expect(vm.v.number.$silentErrors).toEqual([])
     })
   })

--- a/packages/vuelidate/test/unit/test-utils.js
+++ b/packages/vuelidate/test/unit/test-utils.js
@@ -2,3 +2,6 @@ const { isVue3 } = require('vue-demi')
 
 module.exports = isVue3 ? require('@vue/test-utils') : require('@vue/test-utils-vue2')
 module.exports.flushPromises = require('flush-promises')
+const ifTest = (value) => value ? it : it.skip
+module.exports.ifVue2 = ifTest(!isVue3)
+module.exports.ifVue3 = ifTest(isVue3)


### PR DESCRIPTION
## Summary

Adds external validator support to Vuelidate. For each state property, we can have a validation error from the server. It can be a single string or even an array of errors. closes #824 

```
const state = {
  child: 'a',
  nested: {
    nestedChild: 'b'
  }
}

const externalErrors = {
  child: 'Child is not Valid',
  nested: {
    nestedChild: ['Foo', 'bar']
  }
}
```

This adds a `$externalResults` key to the Vuelidate validation object as well as triggers both `$invalid` and `$error` if said property external results are not empty.

## Usage in Composition API

```js
const state = {
  number: 0
}
const $externalResults = ref({});
const v = useVuelidate(rules, state, { $externalResults })

async function addExternalErrors(){
 $externalResults.value = { number: 'Must be above 0' }
}
```

## Usage with Options API

If you need to have external results, just create a `vuelidateExternalResults` object, preferably with the same structure as your state, in the instance data.

```js
export default {
  data: () => ({
    name: 'foo',
    vuelidateExternalResults: { name: 'Must Not be Foo' }
  })
}
```

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
