### PR TITLE
feat(core): adds an $uid property to the $errors objects, fix #843 

### DIFF
--- a/packages/docs/src/.vitepress/config.js
+++ b/packages/docs/src/.vitepress/config.js
@@ -44,7 +44,6 @@ function getAPISidebar () {
   return [
     { text: 'Validation State', link: '/api/state' },
     { text: 'Validation Methods', link: '/api/methods' },
-
     { text: 'Validation Error Object', link: '/api/error_object' },
     { text: 'Validation Configuration', link: '/api/configuration' },
   ]

--- a/packages/docs/src/.vitepress/config.js
+++ b/packages/docs/src/.vitepress/config.js
@@ -44,6 +44,8 @@ function getAPISidebar () {
   return [
     { text: 'Validation State', link: '/api/state' },
     { text: 'Validation Methods', link: '/api/methods' },
+
+    { text: 'Validation Error Object', link: '/api/error_object' },
     { text: 'Validation Configuration', link: '/api/configuration' },
   ]
 }

--- a/packages/docs/src/advanced_usage.md
+++ b/packages/docs/src/advanced_usage.md
@@ -105,7 +105,7 @@ This is the recommended approach when handling collections. Create a new, nested
     <CompB />
 
     <!-- this will contain all $errors and $silentErrors from both <CompA> and <CompB>-->
-    <p v-for="(error, index) of v.$errors" :key="index">
+    <p v-for="error of v.$errors" :key="error.$uid">
       {{ error.$message }}
     </p>
   </div>

--- a/packages/docs/src/api/error_object.md
+++ b/packages/docs/src/api/error_object.md
@@ -1,0 +1,78 @@
+# Error Object
+
+The error object is used to easily check for and output error messages for each validation property.
+
+It is found both in the `$errors` and `$silentErrors` arrays.
+
+```ts
+export interface ErrorObject {
+  $propertyPath: string
+  $property: string
+  $validator: string
+  $message: string | Ref<string>
+  $params: object
+  $pending: boolean
+  $response: any,
+  $uid: string,
+}
+```
+
+## $propertyPath
+
+* **Type:** `String`
+* **Details:**
+
+The deep dot-notation path of the property this validation result belongs to. This will follow deeply nested objects.
+
+* **Example:**
+
+`$propertyPath: "form.users.address.region"`
+
+## $property
+
+* **Type:** `String`
+* **Details:**
+
+The name of the current property, that is being validated.
+
+## $validator
+
+* **Type:** `String`
+* **Details:**
+
+The function name of the validator, for this validation result.
+
+## $message
+
+* **Type:** `String`
+* **Details:**
+
+An optional message, when using `withMessage` helper on validator functions. All `@vuelidate/validators` validators have messages by default.
+
+## $params
+
+* **Type:** `Object`
+* **Details:**
+
+An object that holds a reactive object with optionally passed params to validators via the `withParams` helper.
+
+## $pending
+
+* **Type:** `Boolean`
+* **Details:**
+
+A reactive property, telling whether the validator is still pending. Useful for Async validators.
+
+## $response
+
+* **Type:** `Any`
+* **Details:**
+
+The response returned from a validator. Most often a boolean, unless using the [Extra Validation Data](../advanced_usage.md#returning-extra-data-from-validators) feature.
+
+## $uid
+
+* **Type:** `String`
+* **Details:**
+
+A unique property, to use as a `key` when iterating over validation messages.

--- a/packages/docs/src/guide.md
+++ b/packages/docs/src/guide.md
@@ -176,7 +176,8 @@ triggers `$touch()` for that property.
 
 ### Setting dirty state with `$autoDirty`
 
-It is quite common to forget to use `$model` or `$touch`. If you want to ensure dirty state is always tracked, you can use the `$autoDirty` config param, when defining your validation rules.
+It is quite common to forget to use `$model` or `$touch`. If you want to ensure dirty state is always tracked, you can use the `$autoDirty` config
+param, when defining your validation rules.
 
 ```js
 import useVuelidate from '@vuelidate/core'
@@ -195,7 +196,8 @@ export default {
 }
 ```
 
-This will create an internal watcher, that will update `$dirty`, the moment that field property is changed. It will ensure the validator tracks it's bound data, and sets the dirty state accordingly.
+This will create an internal watcher, that will update `$dirty`, the moment that field property is changed. It will ensure the validator tracks it's
+bound data, and sets the dirty state accordingly.
 
 You can then change your field's `v-model` expression to just the data property:
 
@@ -203,8 +205,8 @@ You can then change your field's `v-model` expression to just the data property:
 <input v-model="name">
 ```
 
-:::tip
-You can pass `$autoDirty` to all validators, by defining it in the global config - [Providing global config to your Vuelidate instance](./advanced_usage.md#providing-global-config-to-your-vuelidate-instance)
+:::tip You can pass `$autoDirty` to all validators, by defining it in the global config
+- [Providing global config to your Vuelidate instance](./advanced_usage.md#providing-global-config-to-your-vuelidate-instance)
 :::
 
 ### Lazy validations
@@ -231,8 +233,8 @@ export default {
 }
 ```
 
-:::tip
-You can pass `$lazy` to all validators, by defining it in the global config - [Providing global config to your Vuelidate instance](./advanced_usage.md#providing-global-config-to-your-vuelidate-instance)
+:::tip You can pass `$lazy` to all validators, by defining it in the global config
+- [Providing global config to your Vuelidate instance](./advanced_usage.md#providing-global-config-to-your-vuelidate-instance)
 :::
 
 ### Resetting dirty state
@@ -287,8 +289,7 @@ flexibility when trying to display error state.
 
 ## Displaying error messages
 
-::: tip NEW IN v2.0
-The built-in validators now all include error messages.
+::: tip NEW IN v2.0 The built-in validators now all include error messages.
 :::
 
 The validation state holds useful data, like the invalid state of each property validator, along with extra properties, like an error message or extra
@@ -298,11 +299,12 @@ Error messages come out of the box with the bundled validators in `@vuelidate/va
 the [Custom Validators page](./custom_validators.md)
 
 The easiest way to display errors is to use the form's top level `$errors` property. It is an array of validation objects, that you can iterate over.
+Use the `$uid` property for your `key`.
 
 ```vue
 <p
-  v-for="(error, index) of v$.$errors"
-  :key="index"
+  v-for="error of v$.$errors"
+  :key="error.$uid"
 >
 <strong>{{ error.$validator }}</strong>
 <small> on property</small>
@@ -316,8 +318,8 @@ You can also check for errors on each form property:
 
 ```vue
 <p
-  v-for="(error, index) of v$.name.$errors"
-  :key="index"
+  v-for="error of v$.name.$errors"
+  :key="error.$uid"
 >
 <!-- Same as above -->
 </p>

--- a/packages/docs/src/index.md
+++ b/packages/docs/src/index.md
@@ -145,7 +145,7 @@ Now that we understand the basic content of the error objects, we can build our 
 ```html
 <div :class="{ error: v$.name.$errors.length }">
   <input v-model="name">
-  <div class="input-errors" v-for="(error, index) of v$.name.$errors">
+  <div class="input-errors" v-for="error of v$.name.$errors" :key="error.$uid">
     <div class="error-msg">{{ error.$message }}</div>
   </div>
 </div>

--- a/packages/docs/src/migration_guide.md
+++ b/packages/docs/src/migration_guide.md
@@ -92,7 +92,7 @@ Here’s the wrapper component.
     />
     <!-- This list will include all errors,
          both from this component and errors from every <PersonInput> -->
-    <div v-for="(error, index) of v$.$errors" :key="index">
+    <div v-for="error of v$.$errors" :key="error.$uid">
       {{ error.$message }}
     </div>
   </div>

--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -87,7 +87,8 @@ export interface ErrorObject {
   readonly $message: string | Ref<string>
   readonly $params: object
   readonly $pending: boolean
-  readonly $response: any
+  readonly $response: any,
+  readonly $uid: string,
 }
 
 type BaseValidation <
@@ -102,6 +103,7 @@ type BaseValidation <
   readonly $dirty: boolean
   readonly $error: boolean
   readonly $errors: ErrorObject[]
+  readonly $silentErrors: ErrorObject[]
   readonly $invalid: boolean
   readonly $anyDirty: boolean
   readonly $pending: boolean

--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -200,6 +200,7 @@ function createValidatorResult (rule, model, $dirty, config, instance) {
  * @property {String} $property - State key
  * @property {String} $propertyPath - Dot notation path to state
  * @property {String} $validator - Validator name
+ * @property {String} $uid - Unique identifier
  */
 
 /**
@@ -292,6 +293,7 @@ function createValidationResults (rules, model, key, resultsCache, path, config,
         $propertyPath: path,
         $property: key,
         $validator: ruleKey,
+        $uid: `${path}-${ruleKey}`,
         $message: res.$message,
         $params: res.$params,
         $response: res.$response,

--- a/packages/vuelidate/test/unit/specs/__snapshots__/validation.spec.js.snap
+++ b/packages/vuelidate/test/unit/specs/__snapshots__/validation.spec.js.snap
@@ -8,6 +8,7 @@ Object {
   "$property": "child",
   "$propertyPath": "level1.child",
   "$response": false,
+  "$uid": "level1.child-isEven",
   "$validator": "isEven",
 }
 `;
@@ -20,6 +21,7 @@ Object {
   "$property": "child",
   "$propertyPath": "level1.child",
   "$response": false,
+  "$uid": "level1.child-isEven",
   "$validator": "isEven",
 }
 `;

--- a/packages/vuelidate/test/unit/specs/optionsApi.spec.js
+++ b/packages/vuelidate/test/unit/specs/optionsApi.spec.js
@@ -85,7 +85,8 @@ describe('OptionsAPI validations', () => {
         $property: 'number',
         $propertyPath: 'number',
         $validator: 'isEven',
-        $response: false
+        $response: false,
+        $uid: 'number-isEven'
       }])
     })
 
@@ -142,7 +143,8 @@ describe('OptionsAPI validations', () => {
         '$property': 'number',
         '$propertyPath': 'number',
         '$validator': 'isEven',
-        $response: false
+        $response: false,
+        $uid: 'number-isEven'
       })
     })
 

--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -125,7 +125,8 @@ describe('useVuelidate', () => {
         $property: 'numberA',
         $propertyPath: 'numberA',
         $validator: 'isEven',
-        $response: false
+        $response: false,
+        $uid: 'numberA-isEven'
       }])
     })
 
@@ -351,7 +352,8 @@ describe('useVuelidate', () => {
         $property: 'number',
         $propertyPath: 'number',
         $validator: 'isEven',
-        $response: false
+        $response: false,
+        $uid: 'number-isEven'
       }])
     })
 
@@ -571,7 +573,8 @@ describe('useVuelidate', () => {
         '$property': 'number',
         '$propertyPath': 'number',
         '$validator': 'isEven',
-        $response: false
+        $response: false,
+        $uid: 'number-isEven'
       })
     })
 

--- a/packages/vuelidate/test/unit/utils.js
+++ b/packages/vuelidate/test/unit/utils.js
@@ -74,7 +74,8 @@ export const shouldBeInvalidValidationObject = ({ v, property, propertyPath = pr
     $property: property,
     $propertyPath: propertyPath,
     $validator: validatorName,
-    $response: false
+    $response: false,
+    $uid: `${propertyPath}-${validatorName}`
   }])
   expect(v).toHaveProperty('$invalid', true)
   expect(v).toHaveProperty('$pending', false)
@@ -93,7 +94,8 @@ export const shouldBeErroredValidationObject = ({ v, property, propertyPath = pr
     $property: property,
     $propertyPath: propertyPath,
     $validator: validatorName,
-    $response: false
+    $response: false,
+    $uid: `${propertyPath}-${validatorName}`
   }])
   expect(v).toHaveProperty('$silentErrors', [{
     $message: '',
@@ -102,7 +104,8 @@ export const shouldBeErroredValidationObject = ({ v, property, propertyPath = pr
     $property: property,
     $propertyPath: propertyPath,
     $validator: validatorName,
-    $response: false
+    $response: false,
+    $uid: `${propertyPath}-${validatorName}`
   }])
   expect(v).toHaveProperty('$invalid', true)
   expect(v).toHaveProperty('$pending', false)


### PR DESCRIPTION
## Summary

This PR adds a `$uid` property to allow for proper `key` usage when iterating over error messages, closes #843 

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
