### PR TITLE
fix(validators): properly pass `this` context to complex validators, closes #831

### DIFF
--- a/packages/validators/src/raw/__tests__/and.spec.js
+++ b/packages/validators/src/raw/__tests__/and.spec.js
@@ -66,4 +66,15 @@ describe('and validator', () => {
     await expect(and(NormalizedValidatorResponseT, NormalizedValidatorResponseT)()).resolves.toBe(true)
     await expect(and(NormalizedValidatorResponseF, NormalizedValidatorResponseF)()).resolves.toBe(false)
   })
+
+  it('calls the functions with the correct `this` context', async () => {
+    const context = { foo: 'foo' }
+
+    const v1 = jest.fn(function () { return this === context })
+
+    const result = await and.call(context, v1)('value', 'vm')
+    expect(v1).toHaveReturnedWith(true)
+    expect(v1).toHaveBeenCalledWith('value', 'vm')
+    expect(result).toEqual(true)
+  })
 })

--- a/packages/validators/src/raw/__tests__/not.spec.js
+++ b/packages/validators/src/raw/__tests__/not.spec.js
@@ -55,4 +55,15 @@ describe('not validator', () => {
     await expect(not(NormalizedValidatorResponseT)('test')).resolves.toBe(false)
     await expect(not(NormalizedValidatorResponseF)('')).resolves.toBe(true)
   })
+
+  it('calls with correct `this` context', async () => {
+    const context = { foo: 'foo' }
+
+    const validator = jest.fn(function () { return this === context })
+
+    const result = await not.call(context, validator)('test', 'vm')
+    expect(validator).toHaveReturnedWith(true)
+    expect(validator).toHaveBeenLastCalledWith('test', 'vm')
+    expect(result).toBe(false)
+  })
 })

--- a/packages/validators/src/raw/__tests__/requiredIf.spec.js
+++ b/packages/validators/src/raw/__tests__/requiredIf.spec.js
@@ -5,25 +5,25 @@ const promiseT = () => Promise.resolve(true)
 const promiseF = () => Promise.resolve(false)
 
 describe('requiredIf validator', () => {
-  it('should not validate empty string when functional condition is met', () => {
-    expect(requiredIf(T)('')).resolves.toBe(false)
+  it('should not validate empty string when functional condition is met', async () => {
+    await expect(requiredIf(T)('')).resolves.toBe(false)
   })
 
-  it('should validate empty string when functional condition not met', () => {
-    expect(requiredIf(F)('')).resolves.toBe(true)
+  it('should validate empty string when functional condition not met', async () => {
+    await expect(requiredIf(F)('')).resolves.toBe(true)
   })
 
-  it('should not validate empty string when simple boolean condition is met', () => {
-    expect(requiredIf('prop')('')).resolves.toBe(false)
+  it('should not validate empty string when simple boolean condition is met', async () => {
+    await expect(requiredIf('prop')('')).resolves.toBe(false)
   })
 
-  it('should validate empty string when simple boolean condition not met', () => {
-    expect(requiredIf('')('')).resolves.toBe(true)
+  it('should validate empty string when simple boolean condition not met', async () => {
+    await expect(requiredIf('')('')).resolves.toBe(true)
   })
 
-  it('should return a promise when passed a promise condition', () => {
+  it('should return a promise when passed a promise condition', async () => {
     const response = requiredIf(promiseT)('')
-    expect(response).toHaveProperty('then') // is a promise
+    await expect(response).toHaveProperty('then') // is a promise
   })
 
   it('should validate value if condition is a truthy promise', async () => {
@@ -40,5 +40,13 @@ describe('requiredIf validator', () => {
     requiredIf(validator)('foo', 'bar')
     expect(validator).toHaveBeenCalledTimes(1)
     expect(validator).toHaveBeenCalledWith('foo', 'bar')
+  })
+
+  it('should have the correct `this` context', async () => {
+    const validator = jest.fn(function () { return this.foo === 'foo' })
+    const context = { foo: 'foo' }
+    const result = await requiredIf.call(context, validator)('value', 'parentVM')
+    expect(validator).toHaveReturnedWith(true)
+    expect(result).toEqual(true)
   })
 })

--- a/packages/validators/src/raw/__tests__/requiredUnless.spec.js
+++ b/packages/validators/src/raw/__tests__/requiredUnless.spec.js
@@ -2,20 +2,28 @@ import requiredUnless from '../requiredUnless'
 import { T, F } from '../../../tests/fixtures'
 
 describe('requiredUnless validator', () => {
-  it('should not validate if prop is falsy', () => {
-    expect(requiredUnless(F)('')).resolves.toBe(false)
-    expect(requiredUnless(F)('truthy value')).resolves.toBe(true)
+  it('should not validate if prop is falsy', async () => {
+    await expect(requiredUnless(F)('')).resolves.toBe(false)
+    await expect(requiredUnless(F)('truthy value')).resolves.toBe(true)
   })
 
-  it('should not validate when prop condition is truthy', () => {
-    expect(requiredUnless(T)('')).resolves.toBe(true)
-    expect(requiredUnless(T)('truthy value')).resolves.toBe(true)
+  it('should not validate when prop condition is truthy', async () => {
+    await expect(requiredUnless(T)('')).resolves.toBe(true)
+    await expect(requiredUnless(T)('truthy value')).resolves.toBe(true)
   })
 
-  it('should pass the value to the validation function', () => {
+  it('should pass the value to the validation function', async () => {
     const validator = jest.fn()
     requiredUnless(validator)('foo', 'bar')
-    expect(validator).toHaveBeenCalledTimes(1)
-    expect(validator).toHaveBeenCalledWith('foo', 'bar')
+    await expect(validator).toHaveBeenCalledTimes(1)
+    await expect(validator).toHaveBeenCalledWith('foo', 'bar')
+  })
+
+  it('should have the correct `this` context', async () => {
+    const validator = jest.fn(function () { return this.foo === 'foo' })
+    const context = { foo: 'foo' }
+    const result = await requiredUnless.call(context, validator)('', '')
+    await expect(validator).toHaveReturnedWith(true)
+    await expect(result).toEqual(true)
   })
 })

--- a/packages/validators/src/raw/and.js
+++ b/packages/validators/src/raw/and.js
@@ -6,7 +6,7 @@ import { unwrapNormalizedValidator, unwrapValidatorResponse } from '../utils/com
  * @return {function(...[*]=): boolean}
  */
 export default function and (...validators) {
-  return function andInternal (...args) {
+  return (...args) => {
     return (
       validators.length > 0 &&
       validators.reduce(async (valid, fn) => await valid && unwrapValidatorResponse(await unwrapNormalizedValidator(fn).apply(this, args)), Promise.resolve(true))

--- a/packages/validators/src/raw/not.js
+++ b/packages/validators/src/raw/not.js
@@ -7,7 +7,7 @@ import { unwrapNormalizedValidator, unwrapValidatorResponse } from '../utils/com
  * @returns {function(*=, *=): boolean}
  */
 export default function (validator) {
-  return async function (value, vm) {
+  return async (value, vm) => {
     return !req(value) || !unwrapValidatorResponse(await unwrapNormalizedValidator(validator).call(this, value, vm))
   }
 }

--- a/packages/validators/src/raw/requiredIf.js
+++ b/packages/validators/src/raw/requiredIf.js
@@ -7,7 +7,7 @@ const validate = (prop, val) => prop ? req(val) : true
  * @return {function(*): (Boolean | Promise<Boolean>)}
  */
 export default function requiredIf (propOrFunction) {
-  return async function requiredIfInternal (value, parentVM) {
+  return async (value, parentVM) => {
     if (typeof propOrFunction !== 'function') {
       return validate(propOrFunction, value)
     }

--- a/packages/validators/src/raw/requiredUnless.js
+++ b/packages/validators/src/raw/requiredUnless.js
@@ -7,7 +7,7 @@ const validate = (prop, val) => !prop ? req(val) : true
  * @return {function(*): (Boolean | Promise<Boolean>)}
  */
 export default function requiredUnless (propOrFunction) {
-  return async function requiredUnlessInternal (value, parentVM) {
+  return async (value, parentVM) => {
     if (typeof propOrFunction !== 'function') {
       return validate(propOrFunction, value)
     }


### PR DESCRIPTION
## Summary

This PR fixes an issue I introduced a while back when refactoring the validators. fixes #831

`this` context should now be properly passed to `requiredIf` and friends.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)