### PR TITLE
feat(core): accept a computed property directly as a validator

### DIFF
--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -776,6 +776,16 @@ describe('useVuelidate', () => {
   })
 
   describe('validators', () => {
+    it('accepts a computed as validator', async () => {
+      const number = ref(0)
+      const isTwo = computed(() => number.value === 2)
+      const { vm } = await createSimpleWrapper({ number: { isTwo } }, { number })
+      expect(vm.v.number.$invalid).toBe(true)
+      number.value = 2
+      await nextTick()
+      expect(vm.v.number.$invalid).toBe(false)
+    })
+
     it('supports a validator to be a function, returning a boolean', async () => {
       const rule = (value) => value === 'foo'
       const value = ref('1')


### PR DESCRIPTION
## Summary

Allow using a `computed` as a validator. This is useful when the validator depends on external reactive properties, not just the model.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
