### PR TITLE
#657: add isRequired param to required* validators

### DIFF
--- a/packages/validators/src/withMessages/required.js
+++ b/packages/validators/src/withMessages/required.js
@@ -6,5 +6,6 @@ import required from '../raw/required'
  */
 export default {
   $validator: required,
-  $message: 'Value is required'
+  $message: 'Value is required',
+  $params: { isRequired: true }
 }

--- a/packages/validators/src/withMessages/requiredIf.js
+++ b/packages/validators/src/withMessages/requiredIf.js
@@ -9,6 +9,6 @@ export default function (prop) {
   return {
     $validator: requiredIf(prop),
     $message: 'The value is required',
-    $params: { isRequired: prop }
+    $params: { isRequired: !!prop }
   }
 }

--- a/packages/validators/src/withMessages/requiredIf.js
+++ b/packages/validators/src/withMessages/requiredIf.js
@@ -8,6 +8,7 @@ import requiredIf from '../raw/requiredIf'
 export default function (prop) {
   return {
     $validator: requiredIf(prop),
-    $message: 'The value is required'
+    $message: 'The value is required',
+    $params: { isRequired: prop }
   }
 }

--- a/packages/validators/src/withMessages/requiredUnless.js
+++ b/packages/validators/src/withMessages/requiredUnless.js
@@ -7,5 +7,6 @@ import requiredUnless from '../raw/requiredUnless'
  */
 export default prop => ({
   $validator: requiredUnless(prop),
-  $message: 'The value is required'
+  $message: 'The value is required',
+  $params: { isRequired: !prop }
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:** #657

Often there is a need to determine whether a validated field is required. This PR adds boolean *isRequired* to *$params* of **required**, **requiredIf** and **requiredUnless** validators to indicate wheter the field is actualy required.

This is useful for example to display a required star in the label of the field without the need to use custom validators.

Please decide whether this is appropriate solution to the problem. Also I'd like to check if the name *isRequired* is adequate. Other validators pass $params with the same name as input params eg. **maxValue**.