### PR TITLE
revert(core): return back to using computed and withAsync

### DIFF
--- a/packages/docs/src/custom_validators.md
+++ b/packages/docs/src/custom_validators.md
@@ -227,7 +227,7 @@ export default {
 
 When your async validator depends internally on other properties, you can pass those as a second parameter to the `withAsync` helper.
 
-Such scenarios can be, when accessing some external refs or reactive stores.
+Such scenarios are common, when relying on some reactive data, different from the validated property.
 
 ```js
 const foo = ref('')
@@ -238,29 +238,39 @@ function validator (value) {
 }
 
 const asyncValidator = withAsync(validator, foo) // here we pass in the `foo` ref as an extra watch target.
+
+const validations = {
+  someProperty: { asyncValidator }
+}
 ```
 
-### Passing multiple values
+### Watching multiple extra values
 
-You can pass multiple extra values to track, by passing an array of refs.
+You can pass multiple extra dependencies to track, by passing an array of refs to `withAsync`.
 
 ```js
 const foo = ref('')
 const bar = reaf(false)
+const validator = () => true
 
-const asyncValidator = withAsync(validator, [foo, bar]) // here we pass in the `foo` ref as an extra watch target.
+const asyncValidator = withAsync(validator, [foo, bar]) // here we pass in the `foo` and `bar` refs, as extra watch targets.
 ```
 
 ### Passing a reactive property
 
-If you want to pass a reactive property, be it when using the Options API, or a `reactive` property, you can just pass a function, or a computed
-property
+To pass a `reactive` property, when using the Options or Composition APis, you can just pass a function returning the correct value, or a computed
+property, returning that value:
 
 ```js
 const store = reactive({ foo: '' })
 
 // when using Composition API
 const asyncValidator = withAsync(validator, () => store.foo)
+
+// or a computed property
+const getter = computed(() => store.foo)
+const asyncValidator = withAsync(validator, getter)
+
 // when using Options API
 export default {
   validatons () {

--- a/packages/docs/src/custom_validators.md
+++ b/packages/docs/src/custom_validators.md
@@ -204,6 +204,75 @@ const validations = {
 };
 ```
 
+## Async validators
+
+Async validators that return a Promise, need to be wrapped in the `withAsync` helper. This will tell Vuelidate to treat the validator in a special
+way, tracking pending status, storing response and more.
+
+```js
+import { helpers } from '@vuelidate/validators'
+
+const { withAsync } = helpers
+export default {
+  data () {
+    return { foo: '' }
+  },
+  validations: {
+    foo: { asyncValidator: withAsync(asyncValidator) }
+  }
+}
+```
+
+### Async validators with extra reactive dependencies
+
+When your async validator depends internally on other properties, you can pass those as a second parameter to the `withAsync` helper.
+
+Such scenarios can be, when accessing some external refs or reactive stores.
+
+```js
+const foo = ref('')
+
+function validator (value) {
+  if (foo.value === 'foo') return false
+  return value === 'bar'
+}
+
+const asyncValidator = withAsync(validator, foo) // here we pass in the `foo` ref as an extra watch target.
+```
+
+### Passing multiple values
+
+You can pass multiple extra values to track, by passing an array of refs.
+
+```js
+const foo = ref('')
+const bar = reaf(false)
+
+const asyncValidator = withAsync(validator, [foo, bar]) // here we pass in the `foo` ref as an extra watch target.
+```
+
+### Passing a reactive property
+
+If you want to pass a reactive property, be it when using the Options API, or a `reactive` property, you can just pass a function, or a computed
+property
+
+```js
+const store = reactive({ foo: '' })
+
+// when using Composition API
+const asyncValidator = withAsync(validator, () => store.foo)
+// when using Options API
+export default {
+  validatons () {
+    return {
+      foo: {
+        validator: withAsync(asyncValidator, () => this.store.foo)
+      }
+    }
+  }
+}
+```
+
 ## List of helpers
 
 This table contains all helpers that can be used to help you with writing your own validators. You can import them from validators library
@@ -216,6 +285,7 @@ import { helpers } from '@vuelidate/validators'
 | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `withParams` | Allows adding `$params` metadata to your validation function.                                                                                 |
 | `withMessage` | Allows adding custom error messages to built-in or custom validators                                                                         |
+| `withAsync`  | Specifies that a validator returns a promise.                                                                         |
 | `req`        | Minimal version of `required` validator. Use it to make your validator accept optional fields                                                 |
 | `len`        | Get length of any kind value, whatever makes sense in the context. This can mean array length, string length, or number of keys on the object |
 | `regex`      | Useful for quick creation of regex based validators.                                                                                          |

--- a/packages/docs/src/migration_guide.md
+++ b/packages/docs/src/migration_guide.md
@@ -161,7 +161,7 @@ This might seem like a lot of overhead, but aside from simple examples like the 
 
 All validators are expected to be synchronous. They are most common, and we use `computed` under the hood to track all possible reactive deps.
 
-### Migration strategy
+#### Migration strategy
 
 If a validators needs to be async, just use the `withAsync` helper to wrap your validators, that return a Promise. This is necessary in order to tell
 Vuelidate to await this validator to resolve.

--- a/packages/docs/src/migration_guide.md
+++ b/packages/docs/src/migration_guide.md
@@ -156,3 +156,23 @@ This might seem like a lot of overhead, but aside from simple examples like the 
 1. It is not limited to only parent-child component relations, as the parent will collect all validation results from any descendant component.
 2. Each of those child components can control how their validation rules should look like.
 3. The parent component doesn't need to know the object structure of the elements in the collection.
+
+## Async validators need to be wrapped in withAsync
+
+All validators are expected to be synchronous. They are most common, and we use `computed` under the hood to track all possible reactive deps.
+
+### Migration strategy
+
+If a validators needs to be async, just use the `withAsync` helper to wrap your validators, that return a Promise. This is necessary in order to tell
+Vuelidate to await this validator to resolve.
+
+```js
+import { helpers } from '@vuelidate/validators'
+
+const { withAsync } = helpers
+export default {
+  validations: {
+    foo: { asyncValidator: withAsync(asyncValidator) }
+  }
+}
+```

--- a/packages/test-project/src/components/SimpleForm.vue
+++ b/packages/test-project/src/components/SimpleForm.vue
@@ -42,7 +42,9 @@ import { ref, reactive, computed } from 'vue'
 import useVuelidate from '@vuelidate/core'
 import { required, helpers, minLength } from '@vuelidate/validators'
 
-const asyncValidator = {
+const { withAsync } = helpers
+
+const asyncValidator = withAsync({
   $message: 'Should be aaaa',
   $validator: (v) => {
     return new Promise(resolve => {
@@ -53,7 +55,7 @@ const asyncValidator = {
       }, 2000)
     })
   }
-}
+})
 
 export default {
   name: 'SimpleForm',

--- a/packages/validators/src/common.js
+++ b/packages/validators/src/common.js
@@ -1,4 +1,5 @@
 export { default as withParams } from './utils/withParams'
 export { default as withMessage } from './utils/withMessage'
+export { default as withAsync } from './utils/withAsync'
 export { req, len, regex } from './raw/core'
 export { unwrap } from './utils/common'

--- a/packages/validators/src/utils/__tests__/withAsync.spec.js
+++ b/packages/validators/src/utils/__tests__/withAsync.spec.js
@@ -1,0 +1,41 @@
+import { NormalizedT, T } from '../../../tests/fixtures'
+import withAsync from '../withAsync'
+import withParams from '../withParams'
+
+describe('withAsync', () => {
+  it('returns an async validator object, when passed a function', () => {
+    expect(withAsync(T)).toEqual({
+      $validator: T,
+      $async: true,
+      $watchTargets: []
+    })
+  })
+
+  it('returns async validator object, when passed a normalised validator objet', () => {
+    expect(withAsync(NormalizedT)).toEqual({
+      $validator: T,
+      $async: true,
+      $watchTargets: []
+    })
+  })
+
+  it('retains $params', () => {
+    expect(withAsync(withParams({ foo: 'foo' }, NormalizedT))).toEqual({
+      $validator: T,
+      $async: true,
+      $watchTargets: [],
+      $params: {
+        foo: 'foo'
+      }
+    })
+  })
+
+  it('allows specifying watch targets', () => {
+    const foo = 'foo'
+    expect(withAsync(NormalizedT, [foo])).toEqual({
+      $validator: T,
+      $async: true,
+      $watchTargets: [foo]
+    })
+  })
+})

--- a/packages/validators/src/utils/__tests__/withMessage.spec.js
+++ b/packages/validators/src/utils/__tests__/withMessage.spec.js
@@ -1,4 +1,5 @@
 import withMessage from '../withMessage'
+import { NormalizedT } from '../../../tests/fixtures'
 
 describe('withMessage', () => {
   const fn = jest.fn()
@@ -41,6 +42,11 @@ describe('withMessage', () => {
       $message: 'msg',
       $validator: validator.$validator
     })
+  })
+
+  it('should not mutate validator', () => {
+    withMessage('Error message', NormalizedT)
+    expect(NormalizedT).not.toHaveProperty('$message')
   })
 
   it('should not call the message function or validator functions', () => {

--- a/packages/validators/src/utils/__tests__/withParams.spec.js
+++ b/packages/validators/src/utils/__tests__/withParams.spec.js
@@ -23,11 +23,21 @@ describe('withParams validator modifier', () => {
     expect(() => withParams({}, [])).toThrowError('Validator must be a function or object with $validator parameter')
   })
 
-  it('should return an object', () => {
-    expect(withParams({}, func)).toEqual({
+  it('should return an object, attaching provided params', () => {
+    const params = {}
+    expect(withParams(params, func)).toEqual({
       $validator: func,
-      $params: {}
+      $params: params
     })
+  })
+
+  it('should not mutate validators', () => {
+    const validator = {
+      $validator: func,
+      $message: 'some message'
+    }
+    withParams({}, validator)
+    expect(validator).not.toHaveProperty('$params')
   })
 
   it('should allow a Validator object to be passed', () => {
@@ -48,7 +58,6 @@ describe('withParams validator modifier', () => {
     expect(fn).not.toHaveBeenCalled()
   })
 
-  // TODO: This changes from $sub to combining into $params. Do we want this?
   it('should stack combining params', () => {
     const $params1 = { a: 0, c: 3 }
     const $params2 = { a: 1, b: 2 }

--- a/packages/validators/src/utils/common.js
+++ b/packages/validators/src/utils/common.js
@@ -18,7 +18,7 @@ export function isObject (o) {
  */
 export function normalizeValidatorObject (validator) {
   return isFunction(validator.$validator)
-    ? validator
+    ? { ...validator }
     : {
       $validator: validator
     }

--- a/packages/validators/src/utils/withAsync.js
+++ b/packages/validators/src/utils/withAsync.js
@@ -1,0 +1,23 @@
+import { normalizeValidatorObject } from './common'
+/**
+ * @typedef {function(*): Promise<boolean|ValidatorResponse>} asyncValidator
+ */
+
+/**
+ * @typedef {Ref<*>[]|function(*): *} watchTargets
+ */
+
+/**
+ * Wraps validators that returns a Promise.
+ * @param {asyncValidator} $validator
+ * @param {watchTargets} $watchTargets
+ * @return {{$async: boolean, $validator: asyncValidator, $watchTargets: watchTargets}}
+ */
+export default function withAsync ($validator, $watchTargets = []) {
+  const validatorObj = normalizeValidatorObject($validator)
+  return {
+    ...validatorObj,
+    $async: true,
+    $watchTargets
+  }
+}

--- a/packages/validators/src/utils/withMessage.js
+++ b/packages/validators/src/utils/withMessage.js
@@ -16,7 +16,7 @@ export default function withMessage ($message, $validator) {
   if (!isFunction($message) && typeof unwrap($message) !== 'string') throw new Error(`[@vuelidate/validators]: First parameter to "withMessage" should be string or a function returning a string, provided ${typeof $message}`)
   if (!isObject($validator) && !isFunction($validator)) throw new Error(`[@vuelidate/validators]: Validator must be a function or object with $validator parameter`)
 
-  const validatorObj = Object.assign({}, normalizeValidatorObject($validator))
+  const validatorObj = normalizeValidatorObject($validator)
   validatorObj.$message = $message
 
   return validatorObj

--- a/packages/validators/src/utils/withParams.js
+++ b/packages/validators/src/utils/withParams.js
@@ -13,7 +13,7 @@ export default function withParams ($params, $validator) {
   const validatorObj = normalizeValidatorObject($validator)
 
   validatorObj.$params = {
-    ...validatorObj.$params,
+    ...(validatorObj.$params || {}),
     ...$params
   }
 

--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -6,6 +6,12 @@ let ROOT_PATH = '__root'
 /**
  * @typedef {import('vue-demi').ComponentPublicInstance} VueInstance
  */
+/**
+ * @typedef {import('vue-demi').ComputedRef} ComputedRef
+ */
+/**
+ * @typedef {import('vue-demi').WatchStopHandle} WatchStopHandle
+ */
 
 /**
  * @typedef NormalizedValidator
@@ -13,6 +19,7 @@ let ROOT_PATH = '__root'
  * @property {String | Ref<String> | function(*): string} [$message]
  * @property {Object | Ref<Object>} [$params]
  * @property {Object | Ref<Object>} [$async]
+ * @property {Ref<*>[]} [$watchTargets]
  */
 
 /**
@@ -83,7 +90,7 @@ function callRule (rule, value, instance) {
  * Normalizes the validator result
  * Allows passing a boolean of an object like `{ $valid: Boolean }`
  * @param {ValidatorResponse} result - Validator result
- * @return {Boolean}
+ * @return {boolean}
  */
 function normalizeValidatorResponse (result) {
   return result.$valid !== undefined
@@ -93,24 +100,25 @@ function normalizeValidatorResponse (result) {
 
 /**
  * Returns the result of an async validator.
- * @param {Function} rule
+ * @param {Validator} rule
  * @param {Ref<*>} model
  * @param {Ref<Boolean>} $pending
  * @param {Ref<Boolean>} $dirty
  * @param {Object} config
  * @param {Ref<*>} $response
  * @param {VueInstance} instance
- * @return {Ref<Boolean>}
+ * @param {Ref<*>[]} watchTargets
+ * @return {{ $invalid: Ref<Boolean>, $unwatch: WatchStopHandle }}
  */
-function createAsyncResult (rule, model, $pending, $dirty, { $lazy }, $response, instance) {
+function createAsyncResult (rule, model, $pending, $dirty, { $lazy }, $response, instance, watchTargets = []) {
   const $invalid = ref(!!$dirty.value)
   const $pendingCounter = ref(0)
 
   $pending.value = false
 
   const $unwatch = watch(
-    [model, $dirty],
-    ([modelValue, dirty]) => {
+    [model, $dirty].concat(watchTargets),
+    () => {
       if ($lazy && !$dirty.value) return false
       let ruleResult
       // make sure we dont break if a validator throws
@@ -145,6 +153,33 @@ function createAsyncResult (rule, model, $pending, $dirty, { $lazy }, $response,
 }
 
 /**
+ * Returns the result of a sync validator
+ * @param {Validator} rule
+ * @param {Ref<*>} model
+ * @param {Ref<Boolean>} $dirty
+ * @param {Object} config
+ * @param {Boolean} config.$lazy
+ * @param {Ref<*>} $response
+ * @param {VueInstance} instance
+ * @return {{$unwatch: (function(): {}), $invalid: ComputedRef<boolean>}}
+ */
+function createSyncResult (rule, model, $dirty, { $lazy }, $response, instance) {
+  const $unwatch = () => ({})
+  const $invalid = computed(() => {
+    if ($lazy && !$dirty.value) return false
+    try {
+      const result = callRule(rule, model, instance)
+      $response.value = result
+      return normalizeValidatorResponse(result)
+    } catch (err) {
+      $response.value = err
+    }
+    return true
+  })
+  return { $unwatch, $invalid }
+}
+
+/**
  * Returns the validation result.
  * Detects async and sync validators.
  * @param {NormalizedValidator} rule
@@ -152,21 +187,36 @@ function createAsyncResult (rule, model, $pending, $dirty, { $lazy }, $response,
  * @param {Ref<boolean>} $dirty
  * @param {Object} config
  * @param {VueInstance} instance
- * @return {{$params: *, $message: Ref<String>, $pending: Ref<Boolean>, $invalid: Ref<Boolean>, $response: Ref<*>}}
+ * @return {{ $params: *, $message: Ref<String>, $pending: Ref<Boolean>, $invalid: Ref<Boolean>, $response: Ref<*>, $unwatch: WatchStopHandle }}
  */
 function createValidatorResult (rule, model, $dirty, config, instance) {
   const $pending = ref(false)
   const $params = rule.$params || {}
   const $response = ref(null)
-  const { $invalid, $unwatch } = createAsyncResult(
-    rule.$validator,
-    model,
-    $pending,
-    $dirty,
-    config,
-    $response,
-    instance
-  )
+  let $invalid
+  let $unwatch
+
+  if (rule.$async) {
+    ({ $invalid, $unwatch } = createAsyncResult(
+      rule.$validator,
+      model,
+      $pending,
+      $dirty,
+      config,
+      $response,
+      instance,
+      rule.$watchTargets
+    ))
+  } else {
+    ({ $invalid, $unwatch } = createSyncResult(
+      rule.$validator,
+      model,
+      $dirty,
+      config,
+      $response,
+      instance
+    ))
+  }
 
   const message = rule.$message
   const $message = isFunction(message)

--- a/packages/vuelidate/test/unit/validations.fixture.js
+++ b/packages/vuelidate/test/unit/validations.fixture.js
@@ -2,6 +2,7 @@ import { computed, h, ref, reactive } from 'vue-demi'
 import { asyncIsEven, isEven, isOdd } from './validators.fixture'
 import { createSimpleComponent } from './utils'
 import { useVuelidate } from '../../src'
+import withAsync from '../../../validators/src/utils/withAsync'
 
 export function nestedReactiveObjectValidation () {
   const state = reactive({
@@ -129,7 +130,7 @@ export function asyncValidation () {
 export function simpleErrorValidation () {
   const errorObject = new Error('message')
   const state = { withPromise: ref(1), noPromise: ref(1) }
-  const asyncValidator = () => Promise.reject(errorObject)
+  const asyncValidator = withAsync(() => Promise.reject(errorObject))
 
   function syncValidator () {
     throw errorObject

--- a/packages/vuelidate/test/unit/validators.fixture.js
+++ b/packages/vuelidate/test/unit/validators.fixture.js
@@ -1,7 +1,9 @@
+import withAsync from '@vuelidate/validators/src/utils/withAsync'
+
 export function toAsync (validator, time = 0) {
-  return (value) => new Promise((resolve) =>
+  return withAsync((value) => new Promise((resolve) =>
     setTimeout(() => resolve(validator(value)), time)
-  )
+  ))
 }
 
 export const isEven = (v) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -349,10 +349,10 @@
   dependencies:
     "@babel/types" "^7.11.0"
 
-"@babel/helper-validator-identifier@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
-  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
+"@babel/helper-validator-identifier@^7.10.4", "@babel/helper-validator-identifier@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
+  integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
 
 "@babel/helper-validator-identifier@^7.9.5":
   version "7.12.11"
@@ -392,10 +392,10 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
   integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
 
-"@babel/parser@^7.12.0":
-  version "7.12.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.3.tgz#a305415ebe7a6c7023b40b5122a0662d928334cd"
-  integrity sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==
+"@babel/parser@^7.12.0", "@babel/parser@^7.13.9":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.2.tgz#0c1680aa44ad4605b16cbdcc5c341a61bde9c746"
+  integrity sha512-IoVDIHpsgE/fu7eXBeRWt8zLbDrSvD7H1gpomOkPpBoEN8KCruCqSDdqo8dddwQQrui30KSvQBaMUOJiuFu6QQ==
 
 "@babel/parser@^7.9.4":
   version "7.9.6"
@@ -1034,13 +1034,12 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.12.0":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.1.tgz#e109d9ab99a8de735be287ee3d6a9947a190c4ae"
-  integrity sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==
+"@babel/types@^7.12.0", "@babel/types@^7.13.0":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.2.tgz#4208ae003107ef8a057ea8333e56eb64d2f6a2c3"
+  integrity sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.10.4"
-    lodash "^4.17.19"
+    "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.4.4":
@@ -2750,14 +2749,14 @@
     estree-walker "^2.0.1"
     source-map "^0.6.1"
 
-"@vue/compiler-core@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.1.tgz#3ce57531078c6220be7ea458e41e4bab3522015b"
-  integrity sha512-BbQQj9YVNaNWEPnP4PiFKgW8QSGB3dcPSKCtekx1586m4VA1z8hHNLQnzeygtV8BM4oU6yriiWmOIYghbJHwFw==
+"@vue/compiler-core@3.0.11":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.11.tgz#5ef579e46d7b336b8735228758d1c2c505aae69a"
+  integrity sha512-6sFj6TBac1y2cWCvYCA8YzHJEbsVkX7zdRs/3yK/n1ilvRqcn983XvpBbnN3v4mZ1UiQycTvOiajJmOgN9EVgw==
   dependencies:
     "@babel/parser" "^7.12.0"
     "@babel/types" "^7.12.0"
-    "@vue/shared" "3.0.1"
+    "@vue/shared" "3.0.11"
     estree-walker "^2.0.1"
     source-map "^0.6.1"
 
@@ -2780,13 +2779,13 @@
     "@vue/compiler-core" "3.0.0-rc.5"
     "@vue/shared" "3.0.0-rc.5"
 
-"@vue/compiler-dom@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.1.tgz#00b12f2e4aa55e624e2a5257e4bed93cf7555f0b"
-  integrity sha512-8cjgswVU2YmV35H9ARZmSlDr1P9VZxUihRwefkrk6Vrsb7kui5C3d/WQ2/su34FSDpyMU1aacUOiL2CV/vdX6w==
+"@vue/compiler-dom@3.0.11":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.11.tgz#b15fc1c909371fd671746020ba55b5dab4a730ee"
+  integrity sha512-+3xB50uGeY5Fv9eMKVJs2WSRULfgwaTJsy23OIltKgMrynnIj8hTYY2UL97HCoz78aDw1VDXdrBQ4qepWjnQcw==
   dependencies:
-    "@vue/compiler-core" "3.0.1"
-    "@vue/shared" "3.0.1"
+    "@vue/compiler-core" "3.0.11"
+    "@vue/shared" "3.0.11"
 
 "@vue/compiler-dom@3.0.5":
   version "3.0.5"
@@ -2819,24 +2818,24 @@
     source-map "^0.6.1"
 
 "@vue/compiler-sfc@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.0.1.tgz#f340f8f75b5c1c4509e0f3a12c79d1544899b663"
-  integrity sha512-VO5gJ7SyHw0hf1rkKXRlxjXI9+Q4ngcuUWYnyjOSDch7Wtt2IdOEiC82KFWIkfWMpHqA5HPzL2nDmys3y9d19w==
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.0.11.tgz#cd8ca2154b88967b521f5ad3b10f5f8b6b665679"
+  integrity sha512-7fNiZuCecRleiyVGUWNa6pn8fB2fnuJU+3AGjbjl7r1P5wBivfl02H4pG+2aJP5gh2u+0wXov1W38tfWOphsXw==
   dependencies:
-    "@babel/parser" "^7.12.0"
-    "@babel/types" "^7.12.0"
-    "@vue/compiler-core" "3.0.1"
-    "@vue/compiler-dom" "3.0.1"
-    "@vue/compiler-ssr" "3.0.1"
-    "@vue/shared" "3.0.1"
+    "@babel/parser" "^7.13.9"
+    "@babel/types" "^7.13.0"
+    "@vue/compiler-core" "3.0.11"
+    "@vue/compiler-dom" "3.0.11"
+    "@vue/compiler-ssr" "3.0.11"
+    "@vue/shared" "3.0.11"
     consolidate "^0.16.0"
     estree-walker "^2.0.1"
     hash-sum "^2.0.0"
     lru-cache "^5.1.1"
     magic-string "^0.25.7"
     merge-source-map "^1.1.0"
-    postcss "^7.0.32"
-    postcss-modules "^3.2.2"
+    postcss "^8.1.10"
+    postcss-modules "^4.0.0"
     postcss-selector-parser "^6.0.4"
     source-map "^0.6.1"
 
@@ -2870,13 +2869,13 @@
     "@vue/compiler-dom" "3.0.0-rc.5"
     "@vue/shared" "3.0.0-rc.5"
 
-"@vue/compiler-ssr@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.0.1.tgz#0455b011d72d4ed02faa93610f14981c3d44a079"
-  integrity sha512-U0Vb7BOniw9rY0/YvXNw5EuIuO0dCoZd3XhnDjAKL9A5pSBxTlx6fPJeQ53gV0XH40M5z8q4yXukFqSVTXC6hQ==
+"@vue/compiler-ssr@3.0.11":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.0.11.tgz#ac5a05fd1257412fa66079c823d8203b6a889a13"
+  integrity sha512-66yUGI8SGOpNvOcrQybRIhl2M03PJ+OrDPm78i7tvVln86MHTKhM3ERbALK26F7tXl0RkjX4sZpucCpiKs3MnA==
   dependencies:
-    "@vue/compiler-dom" "3.0.1"
-    "@vue/shared" "3.0.1"
+    "@vue/compiler-dom" "3.0.11"
+    "@vue/shared" "3.0.11"
 
 "@vue/compiler-ssr@3.0.5":
   version "3.0.5"
@@ -2887,11 +2886,11 @@
     "@vue/shared" "3.0.5"
 
 "@vue/composition-api@^1.0.0-rc.1":
-  version "1.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.0.0-rc.1.tgz#d5286bbaffcd1987e56d5e3a9f26bfb6023e7c41"
-  integrity sha512-6I5LkfA+VvVOLZufRugzQ5sWKQH81/Cr9gRLidDSeUmjRPolEEWgG4MAnWtBR5zgP5qbRMwZJ4IEYtKhnadMQQ==
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.0.0-rc.8.tgz#ace0f1c8cc7d5b193825fabdc7c4b919bb182a9e"
+  integrity sha512-9ZW2+2WW7iNywVFeaz9K18DW/aA4MLncz+FiUpjtMUKzHpiN1GtYQ8rRYOhHfGXD2Hmp4tTFjqaTM4WeAbB1ig==
   dependencies:
-    tslib "^2.0.3"
+    tslib "^2.2.0"
 
 "@vue/reactivity@3.0.0-rc.5":
   version "3.0.0-rc.5"
@@ -2900,12 +2899,12 @@
   dependencies:
     "@vue/shared" "3.0.0-rc.5"
 
-"@vue/reactivity@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.1.tgz#8bf6d88d0fe398e956dd8ea3df206c149ec6b92b"
-  integrity sha512-XWeqNTbvcAq8BmtR5M+XU6mfIhzi1NTcrQho7nI03I+Zf6QW1hHl/ri+iNfCNCasukQI/tzpkqJYPfyZxCRKyg==
+"@vue/reactivity@3.0.11":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.11.tgz#07b588349fd05626b17f3500cbef7d4bdb4dbd0b"
+  integrity sha512-SKM3YKxtXHBPMf7yufXeBhCZ4XZDKP9/iXeQSC8bBO3ivBuzAi4aZi0bNoeE2IF2iGfP/AHEt1OU4ARj4ao/Xw==
   dependencies:
-    "@vue/shared" "3.0.1"
+    "@vue/shared" "3.0.11"
 
 "@vue/reactivity@3.0.5":
   version "3.0.5"
@@ -2922,13 +2921,13 @@
     "@vue/reactivity" "3.0.0-rc.5"
     "@vue/shared" "3.0.0-rc.5"
 
-"@vue/runtime-core@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.1.tgz#75ae586515aaa89e7be790ea0f2c09d436511e4d"
-  integrity sha512-HporlL3cbD0/79U0a7mDIMEn5XoxstVXrOx0TDTi2O2CUv6yjteUQdxhmMOa8m7pnqU4DL/ZuVntBWFaf4ccaw==
+"@vue/runtime-core@3.0.11":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.11.tgz#c52dfc6acf3215493623552c1c2919080c562e44"
+  integrity sha512-87XPNwHfz9JkmOlayBeCCfMh9PT2NBnv795DSbi//C/RaAnc/bGZgECjmkD7oXJ526BZbgk9QZBPdFT8KMxkAg==
   dependencies:
-    "@vue/reactivity" "3.0.1"
-    "@vue/shared" "3.0.1"
+    "@vue/reactivity" "3.0.11"
+    "@vue/shared" "3.0.11"
 
 "@vue/runtime-core@3.0.5":
   version "3.0.5"
@@ -2947,13 +2946,13 @@
     "@vue/shared" "3.0.0-rc.5"
     csstype "^2.6.8"
 
-"@vue/runtime-dom@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.1.tgz#2cc74550a635f38eb5f61f35f374d5bdb55156b0"
-  integrity sha512-ijb2qTRU8OzllzYQ6BSymuu9KHFDyjzn4m6jcLGlNeazdk1/YA01lFtGkl6oAErdiWPglloUJzIz0ilv0laPwA==
+"@vue/runtime-dom@3.0.11":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.11.tgz#7a552df21907942721feb6961c418e222a699337"
+  integrity sha512-jm3FVQESY3y2hKZ2wlkcmFDDyqaPyU3p1IdAX92zTNeCH7I8zZ37PtlE1b9NlCtzV53WjB4TZAYh9yDCMIEumA==
   dependencies:
-    "@vue/runtime-core" "3.0.1"
-    "@vue/shared" "3.0.1"
+    "@vue/runtime-core" "3.0.11"
+    "@vue/shared" "3.0.11"
     csstype "^2.6.8"
 
 "@vue/runtime-dom@3.0.5":
@@ -2978,10 +2977,10 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0-rc.5.tgz#cea2378e3e37363ddc1f5dd158edc9c9b5b3fff0"
   integrity sha512-ZhcgGzBpp+pUzisZgQpM4ctIGgLpYjBj7/rZfbhEPxFHF/BuTV2jmhXvAl8aF9xDAejIcw85xCy92gDSwKtPag==
 
-"@vue/shared@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.1.tgz#48196c056726aa7466d0182698524c84f203006b"
-  integrity sha512-/X6AUbTFCyD2BcJnBoacUct8qcv1A5uk1+N+3tbzDVuhGPRmoYrTSnNUuF53C/GIsTkChrEiXaJh2kyo/0tRvw==
+"@vue/shared@3.0.11":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.11.tgz#20d22dd0da7d358bb21c17f9bde8628152642c77"
+  integrity sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA==
 
 "@vue/shared@3.0.5":
   version "3.0.5"
@@ -4064,6 +4063,11 @@ colorette@^1.2.1:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
   integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
+colorette@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
+  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
+
 columnify@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
@@ -4728,9 +4732,9 @@ cssstyle@^2.2.0:
     cssom "~0.3.6"
 
 csstype@^2.6.8:
-  version "2.6.13"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.13.tgz#a6893015b90e84dd6e85d0e3b442a1e84f2dbe0f"
-  integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
+  version "2.6.17"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.17.tgz#4cf30eb87e1d1a005d8b6510f95292413f6a1c0e"
+  integrity sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -5528,9 +5532,9 @@ estree-walker@^1.0.1:
   integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
 estree-walker@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.1.tgz#f8e030fb21cefa183b44b7ad516b747434e7a3e0"
-  integrity sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -6597,6 +6601,11 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   integrity sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==
   dependencies:
     postcss "^7.0.14"
+
+icss-utils@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
+  integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
 ieee754@^1.1.13:
   version "1.2.1"
@@ -8083,10 +8092,15 @@ lodash@4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.2.1:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.2.1:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.19:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^2.2.0:
   version "2.2.0"
@@ -8597,6 +8611,11 @@ nanoid@^3.1.20:
   version "3.1.20"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
   integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
+
+nanoid@^3.1.23:
+  version "3.1.23"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
+  integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -9565,6 +9584,11 @@ postcss-modules-extract-imports@^2.0.0:
   dependencies:
     postcss "^7.0.5"
 
+postcss-modules-extract-imports@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d"
+  integrity sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==
+
 postcss-modules-local-by-default@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz#f7d80c398c5a393fa7964466bd19500a7d61c069"
@@ -9580,6 +9604,15 @@ postcss-modules-local-by-default@^3.0.2:
   dependencies:
     icss-utils "^4.1.1"
     postcss "^7.0.32"
+    postcss-selector-parser "^6.0.2"
+    postcss-value-parser "^4.1.0"
+
+postcss-modules-local-by-default@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz#ebbb54fae1598eecfdf691a02b3ff3b390a5a51c"
+  integrity sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==
+  dependencies:
+    icss-utils "^5.0.0"
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.1.0"
 
@@ -9599,6 +9632,13 @@ postcss-modules-scope@^2.2.0:
     postcss "^7.0.6"
     postcss-selector-parser "^6.0.0"
 
+postcss-modules-scope@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz#9ef3151456d3bbfa120ca44898dfca6f2fa01f06"
+  integrity sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==
+  dependencies:
+    postcss-selector-parser "^6.0.4"
+
 postcss-modules-values@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz#ecffa9d7e192518389f42ad0e83f72aec456ea20"
@@ -9614,6 +9654,13 @@ postcss-modules-values@^3.0.0:
   dependencies:
     icss-utils "^4.0.0"
     postcss "^7.0.6"
+
+postcss-modules-values@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz#d7c5e7e68c3bb3c9b27cbf48ca0bb3ffb4602c9c"
+  integrity sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==
+  dependencies:
+    icss-utils "^5.0.0"
 
 postcss-modules@^2.0.0:
   version "2.0.0"
@@ -9639,6 +9686,20 @@ postcss-modules@^3.1.0, postcss-modules@^3.2.2:
     postcss-modules-local-by-default "^3.0.2"
     postcss-modules-scope "^2.2.0"
     postcss-modules-values "^3.0.0"
+    string-hash "^1.1.1"
+
+postcss-modules@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules/-/postcss-modules-4.0.0.tgz#2bc7f276ab88f3f1b0fadf6cbd7772d43b5f3b9b"
+  integrity sha512-ghS/ovDzDqARm4Zj6L2ntadjyQMoyJmi0JkLlYtH2QFLrvNlxH5OAVRPWPeKilB0pY7SbuhO173KOWkPAxRJcw==
+  dependencies:
+    generic-names "^2.0.1"
+    icss-replace-symbols "^1.1.0"
+    lodash.camelcase "^4.3.0"
+    postcss-modules-extract-imports "^3.0.0"
+    postcss-modules-local-by-default "^4.0.0"
+    postcss-modules-scope "^3.0.0"
+    postcss-modules-values "^4.0.0"
     string-hash "^1.1.1"
 
 postcss-normalize-charset@^4.0.1:
@@ -9761,13 +9822,11 @@ postcss-selector-parser@^3.0.0:
     uniq "^1.0.1"
 
 postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz#56075a1380a04604c38b063ea7767a129af5c2b3"
-  integrity sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
+  integrity sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==
   dependencies:
     cssesc "^3.0.0"
-    indexes-of "^1.0.1"
-    uniq "^1.0.1"
     util-deprecate "^1.0.2"
 
 postcss-svgo@^4.0.2:
@@ -9825,6 +9884,15 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.27, postcss@^7.0.2
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postcss@^8.1.10:
+  version "8.2.15"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.15.tgz#9e66ccf07292817d226fc315cbbf9bc148fbca65"
+  integrity sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==
+  dependencies:
+    colorette "^1.2.2"
+    nanoid "^3.1.23"
+    source-map "^0.6.1"
 
 postcss@^8.2.1:
   version "8.2.4"
@@ -11642,10 +11710,10 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+tslib@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tsscmp@1.0.6:
   version "1.0.6"
@@ -12098,13 +12166,13 @@ vue@^3.0.0-rc.5:
     "@vue/shared" "3.0.0-rc.5"
 
 vue@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.1.tgz#dcdabf07da37e655e23d7d22eacc18c2da5f5a16"
-  integrity sha512-WBTgaQMJIWQuhlzMV6C0qvVrxyQSpx3gKwflYC0sqGKEZSxMIOYRnrIlHUN4ivUVvP7mUMxcnFTt7P+akdOkQA==
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.11.tgz#c82f9594cbf4dcc869241d4c8dd3e08d9a8f4b5f"
+  integrity sha512-3/eUi4InQz8MPzruHYSTQPxtM3LdZ1/S/BvaU021zBnZi0laRUyH6pfuE4wtUeLvI8wmUNwj5wrZFvbHUXL9dw==
   dependencies:
-    "@vue/compiler-dom" "3.0.1"
-    "@vue/runtime-dom" "3.0.1"
-    "@vue/shared" "3.0.1"
+    "@vue/compiler-dom" "3.0.11"
+    "@vue/runtime-dom" "3.0.11"
+    "@vue/shared" "3.0.11"
 
 vue@^3.0.5:
   version "3.0.5"


### PR DESCRIPTION
## Summary

Reverts back to using `computed` and `withAsync` for async validators.

It adds an extra `watchTargets` featured as a second parameter to `withAsync`. This allows you to provide extra watch targets, when using an async validator, that depends on other reactive properties.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
