### PR TITLE
feat(validators): add type param to validators, closes #657, #856, #866

### DIFF
--- a/packages/validators/src/withMessages/alpha.js
+++ b/packages/validators/src/withMessages/alpha.js
@@ -6,5 +6,8 @@ import alpha from '../raw/alpha'
  */
 export default {
   $validator: alpha,
-  $message: 'The value is not alphabetical'
+  $message: 'The value is not alphabetical',
+  $params: {
+    type: 'alpha'
+  }
 }

--- a/packages/validators/src/withMessages/alphaNum.js
+++ b/packages/validators/src/withMessages/alphaNum.js
@@ -6,5 +6,8 @@ import alphaNum from '../raw/alphaNum'
  */
 export default {
   $validator: alphaNum,
-  $message: 'The value must be alpha-numeric'
+  $message: 'The value must be alpha-numeric',
+  $params: {
+    type: 'alphaNum'
+  }
 }

--- a/packages/validators/src/withMessages/and.js
+++ b/packages/validators/src/withMessages/and.js
@@ -1,4 +1,5 @@
 import and from '../raw/and'
+import { withMessage, withParams } from '../common'
 
 /**
  * Validate if all validators match.
@@ -6,8 +7,9 @@ import and from '../raw/and'
  * @returns {NormalizedValidator}
  */
 export default function (...validators) {
-  return {
-    ...and(...validators),
-    $message: 'The value does not match all of the provided validators'
-  }
+  return withParams({ type: 'and' },
+    withMessage('The value does not match all of the provided validators',
+      and(...validators)
+    )
+  )
 }

--- a/packages/validators/src/withMessages/between.js
+++ b/packages/validators/src/withMessages/between.js
@@ -10,6 +10,6 @@ export default function (min, max) {
   return {
     $validator: between(min, max),
     $message: ({ $params }) => `The value must be between ${$params.min} and ${$params.max}`,
-    $params: { min, max }
+    $params: { min, max, type: 'between' }
   }
 }

--- a/packages/validators/src/withMessages/decimal.js
+++ b/packages/validators/src/withMessages/decimal.js
@@ -6,5 +6,6 @@ import decimal from '../raw/decimal'
  */
 export default {
   $validator: decimal,
-  $message: 'Value must be decimal'
+  $message: 'Value must be decimal',
+  $params: { type: 'decimal' }
 }

--- a/packages/validators/src/withMessages/email.js
+++ b/packages/validators/src/withMessages/email.js
@@ -6,5 +6,6 @@ import email from '../raw/email'
  */
 export default {
   $validator: email,
-  $message: 'Value is not a valid email address'
+  $message: 'Value is not a valid email address',
+  $params: { type: 'email' }
 }

--- a/packages/validators/src/withMessages/integer.js
+++ b/packages/validators/src/withMessages/integer.js
@@ -1,10 +1,11 @@
 import integer from '../raw/integer'
 
-  /**
-   * Validate if value is integer.
-   * @type {NormalizedValidator}
-   */
+/**
+ * Validate if value is integer.
+ * @type {NormalizedValidator}
+ */
 export default {
   $validator: integer,
-  $message: 'Value is not an integer'
+  $message: 'Value is not an integer',
+  $params: { type: 'integer' }
 }

--- a/packages/validators/src/withMessages/ipAddress.js
+++ b/packages/validators/src/withMessages/ipAddress.js
@@ -6,5 +6,6 @@ import ipAddress from '../raw/ipAddress'
  */
 export default {
   $validator: ipAddress,
-  $message: 'The value is not a valid IP address'
+  $message: 'The value is not a valid IP address',
+  $params: { type: 'ipAddress' }
 }

--- a/packages/validators/src/withMessages/macAddress.js
+++ b/packages/validators/src/withMessages/macAddress.js
@@ -7,6 +7,7 @@ import macAddress from '../raw/macAddress'
 export default function (separator) {
   return {
     $validator: macAddress(separator),
-    $message: 'The value is not a valid MAC Address'
+    $message: 'The value is not a valid MAC Address',
+    $params: { type: 'macAddress' }
   }
 }

--- a/packages/validators/src/withMessages/maxLength.js
+++ b/packages/validators/src/withMessages/maxLength.js
@@ -9,6 +9,6 @@ export default function (max) {
   return {
     $validator: maxLength(max),
     $message: ({ $params }) => `The maximum length allowed is ${$params.max}`,
-    $params: { max }
+    $params: { max, type: 'maxLength' }
   }
 }

--- a/packages/validators/src/withMessages/maxValue.js
+++ b/packages/validators/src/withMessages/maxValue.js
@@ -8,5 +8,5 @@ import maxValue from '../raw/maxValue'
 export default max => ({
   $validator: maxValue(max),
   $message: ({ $params }) => `The maximum value is ${$params.max}`,
-  $params: { max }
+  $params: { max, type: 'maxValue' }
 })

--- a/packages/validators/src/withMessages/minLength.js
+++ b/packages/validators/src/withMessages/minLength.js
@@ -9,6 +9,6 @@ export default function (min) {
   return {
     $validator: minLength(min),
     $message: ({ $params }) => `This field should be at least ${$params.min} long`,
-    $params: { min }
+    $params: { min, type: 'minLength' }
   }
 }

--- a/packages/validators/src/withMessages/minValue.js
+++ b/packages/validators/src/withMessages/minValue.js
@@ -9,6 +9,6 @@ export default function (min) {
   return {
     $validator: minValue(min),
     $message: ({ $params }) => `The minimum value allowed is ${$params.min}`,
-    $params: { min }
+    $params: { min, type: 'minValue' }
   }
 }

--- a/packages/validators/src/withMessages/not.js
+++ b/packages/validators/src/withMessages/not.js
@@ -8,6 +8,9 @@ import not from '../raw/not'
 export default function (validator) {
   return {
     $validator: not(validator),
-    $message: `The value does not match the provided validator`
+    $message: `The value does not match the provided validator`,
+    $params: {
+      type: 'not'
+    }
   }
 }

--- a/packages/validators/src/withMessages/numeric.js
+++ b/packages/validators/src/withMessages/numeric.js
@@ -6,5 +6,8 @@ import numeric from '../raw/numeric'
  */
 export default {
   $validator: numeric,
-  $message: 'Value must be numeric'
+  $message: 'Value must be numeric',
+  $params: {
+    type: 'numeric'
+  }
 }

--- a/packages/validators/src/withMessages/or.js
+++ b/packages/validators/src/withMessages/or.js
@@ -1,4 +1,5 @@
 import or from '../raw/or'
+import { withMessage, withParams } from '../common'
 
 /**
  * Returns true when one of the provided functions returns true.
@@ -6,8 +7,8 @@ import or from '../raw/or'
  * @return {NormalizedValidator}
  */
 export default function (...validators) {
-  return {
-    ...or(...validators),
-    $message: 'The value does not match any of the provided validators'
-  }
+  return withParams({ type: 'or' },
+    withMessage('The value does not match any of the provided validators',
+      or(...validators))
+  )
 }

--- a/packages/validators/src/withMessages/required.js
+++ b/packages/validators/src/withMessages/required.js
@@ -6,5 +6,8 @@ import required from '../raw/required'
  */
 export default {
   $validator: required,
-  $message: 'Value is required'
+  $message: 'Value is required',
+  $params: {
+    type: 'required'
+  }
 }

--- a/packages/validators/src/withMessages/requiredIf.js
+++ b/packages/validators/src/withMessages/requiredIf.js
@@ -8,6 +8,7 @@ import requiredIf from '../raw/requiredIf'
 export default function (prop) {
   return {
     $validator: requiredIf(prop),
-    $message: 'The value is required'
+    $message: 'The value is required',
+    $params: { type: 'requiredIf', prop }
   }
 }

--- a/packages/validators/src/withMessages/requiredUnless.js
+++ b/packages/validators/src/withMessages/requiredUnless.js
@@ -5,7 +5,10 @@ import requiredUnless from '../raw/requiredUnless'
  * @param {Boolean | String | function(): (Boolean | Promise<boolean>)} prop
  * @return {NormalizedValidator}
  */
-export default prop => ({
-  $validator: requiredUnless(prop),
-  $message: 'The value is required'
-})
+export default function (prop) {
+  return {
+    $validator: requiredUnless(prop),
+    $message: 'The value is required',
+    $params: { type: 'requiredUnless', prop }
+  }
+}

--- a/packages/validators/src/withMessages/sameAs.js
+++ b/packages/validators/src/withMessages/sameAs.js
@@ -10,6 +10,6 @@ export default function (equalTo, otherName = 'other') {
   return {
     $validator: sameAs(equalTo),
     $message: ({ $params }) => `The value must be equal to the ${otherName} value`,
-    $params: { equalTo, otherName }
+    $params: { equalTo, otherName, type: 'sameAs' }
   }
 }

--- a/packages/validators/src/withMessages/url.js
+++ b/packages/validators/src/withMessages/url.js
@@ -6,5 +6,8 @@ import url from '../raw/url'
  */
 export default {
   $validator: url,
-  $message: 'The value is not a valid URL address'
+  $message: 'The value is not a valid URL address',
+  $params: {
+    type: 'url'
+  }
 }


### PR DESCRIPTION
## Summary

1. Adds `type` to all validator `$params`, so we dont break more complex cases, from Vuelidate 0.x, which provided those.
2. Passes the value for `requiredIf` and `requiredUnless` as a `$param`. This fixes issues with those validators not updating.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included
