### PR TITLE
feature(core): pass more parameters to `$message` to help with i18n support

### DIFF
--- a/packages/test-project/main.js
+++ b/packages/test-project/main.js
@@ -1,8 +1,10 @@
 import { createApp } from 'vue'
 import App from './src/App.vue'
 import { router } from './src/router.js'
+import { i18n } from './src/i18n'
 
 const app = createApp(App)
 
 app.use(router)
+app.use(i18n)
 app.mount('#app')

--- a/packages/test-project/package.json
+++ b/packages/test-project/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "vue": "^3.0.1",
+    "vue-i18n": "^9.1.6",
     "vue-router": "^4.0.0-beta.6"
   },
   "devDependencies": {

--- a/packages/test-project/src/App.vue
+++ b/packages/test-project/src/App.vue
@@ -3,6 +3,7 @@
     <div class="navigation">
       <ul>
         <li><router-link to="/">Simple Form</router-link></li>
+        <li><router-link to="/i18n-simple">i18n Simple Form</router-link></li>
         <li><router-link to="/old-api">Old api</router-link></li>
         <li><router-link to="/nested-validations">Nested Validations</router-link></li>
         <li><router-link to="/nested-ref">Nested Ref</router-link></li>

--- a/packages/test-project/src/components/I18nSimpleForm.vue
+++ b/packages/test-project/src/components/I18nSimpleForm.vue
@@ -1,0 +1,117 @@
+<template>
+  <div class="SimpleForm">
+    <div class="lang-switcher">
+      Change Language to:
+      <a
+        href="#"
+        @click.prevent="$i18n.locale = 'bg'"
+      >BG</a> |
+      <a
+        href="#"
+        @click.prevent="$i18n.locale = 'en'"
+      >EN</a>
+    </div>
+    <div>
+      <label>name</label>
+      <input
+        v-model="name"
+        type="text"
+      >
+    </div>
+    <div>
+      <label>twitter</label>
+      <input
+        v-model="social.twitter"
+        type="text"
+      >
+    </div>
+    <div>
+      <label>github</label>
+      <input
+        v-model="social.github"
+        type="text"
+      >
+    </div>
+    <button @click="validate">
+      Validate
+    </button>
+    <button @click="v$.$touch">
+      $touch
+    </button>
+    <button @click="v$.$reset">
+      $reset
+    </button>
+    <div style="background: rgba(219, 53, 53, 0.62); color: #ff9090; padding: 10px 15px">
+      <p
+        v-for="(error, index) of v$.$errors"
+        :key="index"
+        style="padding: 0; margin: 5px 0"
+      >
+        {{ error.$message }}
+      </p>
+    </div>
+    <pre>{{ v$ }}</pre>
+  </div>
+</template>
+
+<script>
+import { ref, reactive, computed } from 'vue'
+import useVuelidate from '@vuelidate/core'
+import { required, helpers, minLength } from '@vuelidate/validators'
+import { i18n } from '../i18n'
+
+const { global: { t } } = i18n
+const { withAsync } = helpers
+
+const asyncValidator = withAsync((v) => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(v === 'aaaa')
+    }, 2000)
+  })
+})
+
+const withI18nMessage = (validator) => helpers.withMessage((props) => t(`messages.${props.$validator}`, {
+  model: props.$model,
+  property: props.$property,
+  ...props.$params
+}), validator)
+
+export default {
+  name: 'I18nForm',
+  setup () {
+    const name = ref('given name')
+    const social = reactive({
+      github: 'hi',
+      twitter: 'hey'
+    })
+
+    let v$ = useVuelidate(
+      {
+        name: {
+          required: withI18nMessage(required),
+          asyncValidator: withI18nMessage(asyncValidator)
+        },
+        social: {
+          github: { minLength: withI18nMessage(minLength(computed(() => social.twitter.length))) },
+          twitter: { minLength: withI18nMessage(minLength(computed(() => name.value.length))) }
+        }
+      },
+      { name, social },
+      { $autoDirty: true }
+    )
+    return { name, v$, social }
+  },
+  methods: {
+    async validate () {
+      const result = await this.v$.$validate()
+      console.log('Result is', result)
+    }
+  }
+}
+</script>
+<style>
+.lang-switcher a {
+  color: white;
+}
+</style>

--- a/packages/test-project/src/i18n.js
+++ b/packages/test-project/src/i18n.js
@@ -1,0 +1,23 @@
+import { createI18n } from 'vue-i18n'
+
+const messages = {
+  en: {
+    messages: {
+      required: '{property} is required',
+      minLength: 'The {property} field has a value of "{model}", but must have a min length of {min}.',
+      asyncValidator: '{property} should equal "aaaa", but it is "{model}".'
+    }
+  },
+  bg: {
+    messages: {
+      required: '{property} e задължително',
+      minLength: 'Полето {property} има стойност "{model}", но трябва да е дълго поне {min} символа.',
+      asyncValidator: '{property} трябва да е "aaaa", но е "{model}".'
+    }
+  }
+}
+
+export const i18n = createI18n({
+  locale: 'en',
+  messages
+})

--- a/packages/test-project/src/routes.js
+++ b/packages/test-project/src/routes.js
@@ -2,11 +2,16 @@ import SimpleForm from './components/SimpleForm.vue'
 import NestedValidations from './components/NestedValidations.vue'
 import OldApiExample from './components/OldApiExample.vue'
 import ChainOfRefs from './components/ChainOfRefs.vue'
+import I18nSimpleForm from './components/I18nSimpleForm.vue'
 
 export const routes = [
   {
     path: '/',
     component: SimpleForm
+  },
+  {
+    path: '/i18n-simple',
+    component: I18nSimpleForm
   },
   {
     path: '/nested-validations',

--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -186,8 +186,11 @@ function createSyncResult (rule, model, $dirty, { $lazy }, $response, instance) 
  * @param {NormalizedValidator} rule
  * @param {Ref<*>} model
  * @param {Ref<boolean>} $dirty
- * @param {GlobalConfig} config
- * @param {VueInstance} instance
+ * @param {GlobalConfig} config - Vuelidate config
+ * @param {VueInstance} instance - component instance
+ * @param {string} validatorName - name of the current validator
+ * @param {string} propertyKey - the current property we are validating
+ * @param {string} propertyPath - the deep path to the validated property
  * @return {{ $params: *, $message: Ref<String>, $pending: Ref<Boolean>, $invalid: Ref<Boolean>, $response: Ref<*>, $unwatch: WatchStopHandle }}
  */
 function createValidatorResult (rule, model, $dirty, config, instance, validatorName, propertyKey, propertyPath) {

--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -189,7 +189,7 @@ function createSyncResult (rule, model, $dirty, { $lazy }, $response, instance) 
  * @param {VueInstance} instance
  * @return {{ $params: *, $message: Ref<String>, $pending: Ref<Boolean>, $invalid: Ref<Boolean>, $response: Ref<*>, $unwatch: WatchStopHandle }}
  */
-function createValidatorResult (rule, model, $dirty, config, instance) {
+function createValidatorResult (rule, model, $dirty, config, instance, validatorName, propertyKey, propertyPath) {
   const $pending = ref(false)
   const $params = rule.$params || {}
   const $response = ref(null)
@@ -227,7 +227,10 @@ function createValidatorResult (rule, model, $dirty, config, instance) {
           $invalid,
           $params: unwrapObj($params), // $params can hold refs, so we unwrap them for easy access
           $model: model,
-          $response
+          $response,
+          $validator: validatorName,
+          $propertyPath: propertyPath,
+          $property: propertyKey
         })
       ))
     : message || ''
@@ -319,7 +322,10 @@ function createValidationResults (rules, model, key, resultsCache, path, config,
       model,
       result.$dirty,
       config,
-      instance
+      instance,
+      ruleKey,
+      key,
+      path
     )
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,6 +1334,62 @@
   resolved "https://registry.yarnpkg.com/@francoischalifour/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.0.0-alpha.28.tgz#a5ad7996f42e43e4acbb4e0010d663746d0e9997"
   integrity sha512-bprfNmYt1opFUFEtD2XfY/kEsm13bzHQgU80uMjhuK0DJ914IjolT1GytpkdM6tJ4MBvyiJPP+bTtWO+BZ7c7w==
 
+"@intlify/core-base@9.1.6":
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-9.1.6.tgz#887fbeafe37d955bac50318f30ac589839f0d9fb"
+  integrity sha512-d5GDPpsQbqPkisSJA5b6nJFEkalY/IHAd7vOLNd/Sj4YaNRzXtInu2FoqKiOv8e/lQnXGTpurdCZg5Jxq1Gsxw==
+  dependencies:
+    "@intlify/devtools-if" "9.1.6"
+    "@intlify/message-compiler" "9.1.6"
+    "@intlify/message-resolver" "9.1.6"
+    "@intlify/runtime" "9.1.6"
+    "@intlify/shared" "9.1.6"
+    "@intlify/vue-devtools" "9.1.6"
+
+"@intlify/devtools-if@9.1.6":
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/@intlify/devtools-if/-/devtools-if-9.1.6.tgz#739b195e430e24fbf8f864ec8a51e243e3347385"
+  integrity sha512-m8Api+kh+BtFa2FZ/JjIdr1ibsGGqBjdKCzWo5BZecEUxBquIeOQZwpokPh/0K5j+/PZleFXkVAMC5mNt+9WdA==
+  dependencies:
+    "@intlify/shared" "9.1.6"
+
+"@intlify/message-compiler@9.1.6":
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-9.1.6.tgz#e3e99165c1e6ecc496211017799ae59e15b05a18"
+  integrity sha512-DR8645VOrVK6x/8tkaCpHnckMAIcoOgeNS5j0wB12RfZoXYQp7vAXMaOP511KMll2mXCREgIB0ojpajiof7yzQ==
+  dependencies:
+    "@intlify/message-resolver" "9.1.6"
+    "@intlify/shared" "9.1.6"
+    source-map "0.6.1"
+
+"@intlify/message-resolver@9.1.6":
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/@intlify/message-resolver/-/message-resolver-9.1.6.tgz#d7493c9f326d5feb0cd8538a6735b648a91d8f2f"
+  integrity sha512-UUnbawQa5U9sffd5wRIscqtyY1xWlwJbyfwCLPEWLvBhyAnCwPYlvaHGnnO0CSi0fzJTVwlV9DYzobh3agDeMA==
+
+"@intlify/runtime@9.1.6":
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/@intlify/runtime/-/runtime-9.1.6.tgz#bf1548d9034c80eef92b06b240cb347effb41f71"
+  integrity sha512-U1QZ+TPf3kQQvWo4BA2mj3cHAxMRHXNTBhu2u+deh6ubTqXdZ19XGBTMSasrXG6RE+zSio9oM+ndoLja7JGtPg==
+  dependencies:
+    "@intlify/message-compiler" "9.1.6"
+    "@intlify/message-resolver" "9.1.6"
+    "@intlify/shared" "9.1.6"
+
+"@intlify/shared@9.1.6":
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-9.1.6.tgz#d03c9301898d6ddffe2a54c03e7664174fbcdfd9"
+  integrity sha512-6MtsKulyfZxdD7OuxjaODjj8QWoHCnLFAk4wkWiHqBCa6UCTC0qXjtEeZ1MxpQihvFmmJZauBUu25EvtngW5qQ==
+
+"@intlify/vue-devtools@9.1.6":
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/@intlify/vue-devtools/-/vue-devtools-9.1.6.tgz#88faadf203951a2a10107440fa99b58f4637d40d"
+  integrity sha512-UdNovg4OML9rIr1sOGZzTfNr1nUy4UQpDf5ni4dNC93T6FIkVJz0n1Np7Vp7e6gDjcmufRYcV99tEwjQSN9+5A==
+  dependencies:
+    "@intlify/message-resolver" "9.1.6"
+    "@intlify/runtime" "9.1.6"
+    "@intlify/shared" "9.1.6"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -2891,6 +2947,11 @@
   integrity sha512-9ZW2+2WW7iNywVFeaz9K18DW/aA4MLncz+FiUpjtMUKzHpiN1GtYQ8rRYOhHfGXD2Hmp4tTFjqaTM4WeAbB1ig==
   dependencies:
     tslib "^2.2.0"
+
+"@vue/devtools-api@^6.0.0-beta.7":
+  version "6.0.0-beta.12"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.0.0-beta.12.tgz#693ffc77bfb66b080e5c9576abb5786c85470a32"
+  integrity sha512-PtHmAxFmCyCElV7uTWMrXj+fefwn4lCfTtPo9fPw0SK8/7e3UaFl8IL7lnugJmNFfeKQyuTkSoGvTq1uDaRF6Q==
 
 "@vue/reactivity@3.0.0-rc.5":
   version "3.0.0-rc.5"
@@ -11034,15 +11095,15 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
-
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 source-map@^0.7.3:
   version "0.7.3"
@@ -12137,6 +12198,16 @@ vue-eslint-parser@^7.0.0:
     espree "^6.2.1"
     esquery "^1.0.1"
     lodash "^4.17.15"
+
+vue-i18n@^9.1.6:
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-9.1.6.tgz#4cf992e2aec5458bc19369973c96ea7d0f560321"
+  integrity sha512-FEC4HZkTH6QRIu/A0wlo0VS/GH3w/fuCC6xfvoC8IyhhtbG9A+go9NfW+HZ1ZXdAcO4EWcVQi04M+iSwuxgixw==
+  dependencies:
+    "@intlify/core-base" "9.1.6"
+    "@intlify/shared" "9.1.6"
+    "@intlify/vue-devtools" "9.1.6"
+    "@vue/devtools-api" "^6.0.0-beta.7"
 
 vue-router@^4.0.0-beta.6:
   version "4.0.0-beta.13"


### PR DESCRIPTION
## Summary

This PR adds a few extra properties to the `$message` function parameters, so its super easy to create simple and reusable translations on the client side. closes #769

We could probably have our own layer on top of `$message`, that ships with all messages in a file or something, so its easy for users to just provide their own instance of `$t` but I think the solution I provided in the docs is fine as is.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
