### PR TITLE
Add support for function validators to `withI18nMessage`

### DIFF
--- a/packages/docs/src/advanced_usage.md
+++ b/packages/docs/src/advanced_usage.md
@@ -603,11 +603,17 @@ import { i18n } from "@/i18n"
 
 const { t } = i18n.global || i18n // this should work for both Vue 2 and Vue 3 versions of vue-i18n
 
-export const withI18nMessage = (validator) => helpers.withMessage((props) => t(`messages.${props.$validator}`, {
-  model: props.$model,
-  property: props.$property,
-  ...props.$params
-}), validator)
+export const withI18nMessage = (validator, args = null) => {
+  if (validator instanceof Function && args === null) {
+    return (...args) => withI18nMessage(validator, args)
+  }
+
+  return validators.helpers.withMessage((props) => t(`messages.${props.$validator}`, {
+    model: props.$model,
+    property: props.$property,
+    ...props.$params
+  }), args === null ? validator : validator(...args))
+}
 ```
 
 We can now use the validators as we normally do
@@ -615,12 +621,12 @@ We can now use the validators as we normally do
 ```vue
 
 <script>
-import { required } from '@/utils/validators'
+import { required, minLength } from '@/utils/validators'
 
 export default {
   validations () {
     return {
-      name: { required }
+      name: { required, minLength: minLength(3) }
     }
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The `withI18nMessage` function proposed in the https://vuelidate-next.netlify.app/advanced_usage.html#i18n-support does not seem to work with function validators like `minLength`. I modified the function for it to be able to handle those validators well.