### PR TITLE
fix(types): allow reactive ServerErrors in GlobalConfig

### DIFF
--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -170,7 +170,7 @@ interface GlobalConfig {
   $stopPropagation?: boolean
   $autoDirty?: boolean
   $lazy?: boolean,
-  $externalResults?: ServerErrors
+  $externalResults?: ServerErrors | Ref<ServerErrors>
 }
 
 export function useVuelidate(globalConfig?: GlobalConfig): Ref<Validation>;

--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -1,4 +1,4 @@
-import { Ref, defineComponent, App } from 'vue-demi';
+import { Ref, UnwrapRef, defineComponent, App } from 'vue-demi';
 type Component = ReturnType<typeof defineComponent>;
 
 /*
@@ -170,7 +170,7 @@ interface GlobalConfig {
   $stopPropagation?: boolean
   $autoDirty?: boolean
   $lazy?: boolean,
-  $externalResults?: ServerErrors | Ref<ServerErrors>
+  $externalResults?: ServerErrors | Ref<ServerErrors> | UnwrapRef<ServerErrors>
 }
 
 export function useVuelidate(globalConfig?: GlobalConfig): Ref<Validation>;


### PR DESCRIPTION
If provided, the reactivity of `$externalResults` already works correctly if a `Ref<ServerErrors>`  is passed. However it's currently not allowed by the typescript definition.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
