### PR TITLE
feat(types): added TS cast support to `or`, `not`, `and`. Added vm params in `ValidatorFn`

### DIFF
--- a/packages/validators/index.d.ts
+++ b/packages/validators/index.d.ts
@@ -9,8 +9,8 @@ import { Ref } from 'vue-demi';
 // Rules
 export const alpha: ValidationRuleWithoutParams;
 export const alphaNum: ValidationRuleWithoutParams;
-export const and: (
-  ...validators: ValidationRule[]
+export const and: <T = unknown>(
+  ...validators: ValidationRule<T>[]
 ) => ValidationRuleWithoutParams;
 export const between: (
   min: number | Ref<number>,
@@ -33,10 +33,10 @@ export const minLength: (
 export const minValue: (
   min: number | Ref<number> | string | Ref<string>
 ) => ValidationRuleWithParams<{ min: number }>;
-export const not: (validator: ValidationRule) => ValidationRuleWithoutParams;
+export const not: <T = unknown>(validator: ValidationRule<T>) => ValidationRuleWithoutParams;
 export const numeric: ValidationRuleWithoutParams;
-export const or: (
-  ...validators: ValidationRule[]
+export const or: <T = unknown>(
+  ...validators: ValidationRule<T>[]
 ) => ValidationRuleWithoutParams;
 export const required: ValidationRuleWithoutParams;
 export const requiredIf: (prop: boolean | string | (() => boolean | Promise<boolean>)) => ValidationRuleWithoutParams;

--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -40,7 +40,7 @@ export interface ValidatorResponse {
   [key: string]: any
 }
 
-export type ValidatorFn <T = unknown> = (value: T) => boolean | ValidatorResponse | Promise<boolean | ValidatorResponse>;
+export type ValidatorFn <T = unknown> = (value: T, vm: Vue) => boolean | ValidatorResponse | Promise<boolean | ValidatorResponse>;
 
 export interface ValidationRuleWithoutParams <T = unknown> {
   $validator: ValidatorFn<T>


### PR DESCRIPTION
Added TS cast support and vm params


**What kind of change does this PR introduce?** (check at least one)

- [x] Feature
**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

Fellowing previous PR, I added more Typescript upgrades for validators.

- `and`: support for type casting
- `or`: support for type casting
- `not`: support for type casting
- `ValidatorFn`: added `vm: Vue` as second param to access current instance
