### PR TITLE
chore: add repository for all packages.json

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuelidate/vuelidate.git"
+    "url": "https://github.com/vuelidate/vuelidate",
+    "directory": "packages/components"
   },
   "module": "dist/index.esm.js",
   "main": "dist/index.js",

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -5,7 +5,11 @@
   "main": "dist/index.js",
   "types": "index.d.ts",
   "module": "dist/index.esm.js",
-  "repository": "https://github.com/vuelidate/vuelidate",
+  "repository": {
+    "url": "https://github.com/vuelidate/vuelidate",
+    "type": "git",
+    "directory": "packages/validators"
+  },
   "license": "MIT",
   "scripts": {
     "build": "bili src src/raw --format esm --format cjs",

--- a/packages/vuelidate/package.json
+++ b/packages/vuelidate/package.json
@@ -5,7 +5,11 @@
   "main": "dist/index.js",
   "types": "index.d.ts",
   "module": "dist/index.esm.js",
-  "repository": "https://github.com/vuelidate/vuelidate",
+  "repository": {
+    "url": "https://github.com/vuelidate/vuelidate",
+    "type": "git",
+    "directory": "packages/vuelidate"
+  },
   "license": "MIT",
   "files": [
     "dist",


### PR DESCRIPTION
> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
> ```json
> "repository": {
>   "type" : "git",
>   "url" : "https://github.com/facebook/react.git",
>   "directory": "packages/react-dom"
> }
> ```
> — https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

I use a lot https://njt.vercel.app/ to jump to different packages information,
and with this PR we can know exactly what package in what folder lives


Made the changes with a script to make it easier 🙂

https://gist.github.com/iamandrewluca/5cc85b56a595056f0099d04ed6dd8a79
