### PR TITLE
build: reduce transpilation, by removing IE target entirely, fix #895

### DIFF
--- a/packages/components/.browserslistrc
+++ b/packages/components/.browserslistrc
@@ -1,4 +1,4 @@
 last 2 versions
 > 1%
 not dead
-not IE 11
+not ie > 0

--- a/packages/vuelidate/.browserslistrc
+++ b/packages/vuelidate/.browserslistrc
@@ -5,4 +5,3 @@ last 2 versions
 maintained node versions
 not dead
 not ie > 0
-


### PR DESCRIPTION
## Summary

Fixes #895 by removing IE as a build target, drastically reducing transpilation

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `next` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
