### PR TITLE
fix: change async validators to return invalid, only after they resolve, fixes #875

### DIFF
--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -132,7 +132,8 @@ function createAsyncResult (rule, model, $pending, $dirty, { $lazy }, $response,
 
       $pendingCounter.value++
       $pending.value = !!$pendingCounter.value
-      $invalid.value = true
+      // ensure $invalid is false, while validator is resolving
+      $invalid.value = false
 
       Promise.resolve(ruleResult)
         .then(data => {
@@ -358,7 +359,7 @@ function createValidationResults (rules, model, key, resultsCache, path, config,
   )
 
   result.$error = computed(() =>
-    result.$invalid.value && result.$dirty.value
+    result.$dirty.value ? result.$pending.value || result.$invalid.value : false
   )
 
   result.$silentErrors = computed(() => ruleKeys
@@ -506,7 +507,7 @@ function createMetaFields (results, nestedResults, childResults) {
     $dirty.value
   )
 
-  const $error = computed(() => ($invalid.value && $dirty.value) || false)
+  const $error = computed(() => $dirty.value ? $pending.value || $invalid.value : false)
 
   const $touch = () => {
     // call the root $touch

--- a/packages/vuelidate/test/unit/specs/optionsApi.spec.js
+++ b/packages/vuelidate/test/unit/specs/optionsApi.spec.js
@@ -223,7 +223,8 @@ describe('OptionsAPI validations', () => {
       await nextTick()
 
       expect(vm.v.number.asyncIsEven.$pending).toBe(true)
-      expect(vm.v.number.$invalid).toBe(true)
+      expect(vm.v.number.$invalid).toBe(false)
+      expect(vm.v.number.$error).toBe(true)
 
       jest.advanceTimersByTime(6)
       await nextTick()


### PR DESCRIPTION
## Summary

Sets $error to `true`, if a validator is `pending`, but does not show error messages for said field. fixes #875 

### Details

1. A field will still have `$error==true`, while the validator is resolving.
2. A field is considered under error, if any of its child validators are still pending.
3. If you dont debounce async validators, new invocations while previous ones resolve, will reset the `invalid` state to `false`.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
