### PR TITLE
fix(core): reset the $externalResults key for a changed property, closes #891

### DIFF
--- a/packages/docs/src/advanced_usage.md
+++ b/packages/docs/src/advanced_usage.md
@@ -518,26 +518,16 @@ async function validate () {
   await doAsyncStuff()
   // do server validation, and assume we have these errors
   const errors = {
+    // foo: 'error', is also supported
     foo: ['Error one', 'Error Two']
   }
   // add the errors into the external results object
-  $externalResults.value = errors // if using a `reactive` object instead, use `Object.assign($externalResults, errors)`
+  $externalResults.value = errors
+  // if using a `reactive` object instead,
+  // Object.assign($externalResults, errors)
 }
 
 return { v, validate }
-```
-
-To clear out the external results, you should use the handy `$clearExternalResults()` method, that Vuelidate provides. It will properly handle
-both `ref` and `reactive` objects.
-
-```js
-async function validate () {
-  // clear out old external results
-  v.value.$clearExternalResults()
-  // check if everything is valid
-  if (!await v.value.$validate()) return
-  //
-}
 ```
 
 ### External results with Options API
@@ -579,6 +569,26 @@ async function validate () {
   this.$v.value.$clearExternalResults()
   // perform validations
   const result = await this.runAsyncValidators()
+}
+```
+
+### Clearing $externalResults
+
+If you are using `$model` to modify your form state, Vuelidate automatically will clear any corresponding external results.
+
+If you are using `$autoDirty: true`, then Vuelidate will track any changes to your form state and reset the external results as well, no need to
+use `$model`
+
+If you need to clear the entire object, use the handy `$clearExternalResults()` method, that Vuelidate provides. It will properly handle both `ref`
+and `reactive` objects.
+
+```js
+async function validate () {
+  // clear out old external results
+  v.value.$clearExternalResults()
+  // check if everything is valid
+  if (!await v.value.$validate()) return
+  //
 }
 ```
 

--- a/packages/test-project/src/App.vue
+++ b/packages/test-project/src/App.vue
@@ -8,6 +8,7 @@
         <li><router-link to="/nested-validations">Nested Validations</router-link></li>
         <li><router-link to="/nested-ref">Nested Ref</router-link></li>
         <li><router-link to="/collection-validations">Collection Validations</router-link></li>
+        <li><router-link to="/external-validations">External Validations</router-link></li>
       </ul>
     </div>
     <router-view />

--- a/packages/test-project/src/components/ExternalValidationsForm.vue
+++ b/packages/test-project/src/components/ExternalValidationsForm.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="SimpleForm">
+    <label>name</label>
+    <input
+      v-model="name"
+      type="text"
+    >
+    <label>twitter</label>
+    <input
+      v-model="social.twitter"
+      type="text"
+    >
+    <label>github</label>
+    <input
+      v-model="social.github"
+      type="text"
+    >
+    <button @click="validate">
+      Validate
+    </button>
+    <button @click="v$.$touch">
+      $touch
+    </button>
+    <button @click="v$.$reset">
+      $reset
+    </button>
+    <div style="background: rgba(219, 53, 53, 0.62); color: #ff9090; padding: 10px 15px">
+      <p
+        v-for="(error, index) of v$.$errors"
+        :key="index"
+        style="padding: 0; margin: 5px 0"
+      >
+        {{ error.$message }}
+      </p>
+    </div>
+    <pre>{{ v$ }}</pre>
+  </div>
+</template>
+
+<script>
+import { ref, reactive } from 'vue'
+import useVuelidate from '@vuelidate/core'
+import { required, helpers, minLength } from '@vuelidate/validators'
+
+export default {
+  name: 'ExternalValidationsForm',
+  setup () {
+    const name = ref('given name')
+    const social = reactive({
+      github: 'hi',
+      twitter: 'hey'
+    })
+
+    const $externalResults = reactive({
+      name: '',
+      social: {
+        github: '',
+        twitter: ''
+      }
+    })
+
+    let v$ = useVuelidate(
+      {
+        name: {
+          required: helpers.withMessage('This field is required', required)
+        },
+        social: {
+          github: { minLength: minLength(5) },
+          twitter: { minLength: minLength(5) }
+        }
+      }, { name, social }, { $autoDirty: true, $externalResults })
+
+    return { name, v$, social, external: $externalResults }
+  },
+  methods: {
+    validate () {
+      this.v$.$validate().then((result) => {
+        console.log('Result is', result)
+        this.external.name = 'Name External'
+        this.external.social.github = 'Github External'
+      })
+    }
+  }
+}
+</script>

--- a/packages/test-project/src/routes.js
+++ b/packages/test-project/src/routes.js
@@ -4,6 +4,7 @@ import OldApiExample from './components/OldApiExample.vue'
 import ChainOfRefs from './components/ChainOfRefs.vue'
 import CollectionValidations from './components/CollectionValidations.vue'
 import I18nSimpleForm from './components/I18nSimpleForm.vue'
+import ExternalValidationsForm from './components/ExternalValidationsForm.vue'
 
 export const routes = [
   {
@@ -29,5 +30,9 @@ export const routes = [
   {
     path: '/collection-validations',
     component: CollectionValidations
+  },
+  {
+    path: '/external-validations',
+    component: ExternalValidationsForm
   }
 ]

--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -340,7 +340,7 @@ function createValidationResults (rules, model, key, resultsCache, path, config,
       $propertyPath: path,
       $property: key,
       $validator: '$externalResults',
-      $uid: `${path}-${index}`,
+      $uid: `${path}-externalResult-${index}`,
       $message: stringError,
       $params: {},
       $response: null,
@@ -643,6 +643,10 @@ export function setValidations ({
     set: val => {
       $dirty.value = true
       const s = unwrap(state)
+      const external = unwrap(externalResults)
+      if (external) {
+        external[key] = cachedExternalResults[key]
+      }
       if (isRef(s[key])) {
         s[key].value = val
       } else {
@@ -652,12 +656,12 @@ export function setValidations ({
   }) : null
 
   if (key && mergedConfig.$autoDirty) {
-    const $unwatch = watch(nestedState, () => {
-      const autoDirtyPath = `_${path}_$watcher_`
-      const cachedAutoDirty = resultsCache.get(autoDirtyPath, {})
+    watch(nestedState, () => {
       if (!$dirty.value) $touch()
-      if (cachedAutoDirty) cachedAutoDirty.$unwatch()
-      resultsCache.set(autoDirtyPath, {}, { $unwatch })
+      const external = unwrap(externalResults)
+      if (external) {
+        external[key] = cachedExternalResults[key]
+      }
     }, { flush: 'sync' })
   }
 

--- a/packages/vuelidate/test/unit/specs/optionsApi.spec.js
+++ b/packages/vuelidate/test/unit/specs/optionsApi.spec.js
@@ -313,75 +313,82 @@ describe('OptionsAPI validations', () => {
   })
 
   describe('external results', () => {
-    it('saves external results, by changing individual properties', async () => {
+    const externalErrorObject = {
+      $message: 'foo',
+      $params: {},
+      $pending: false,
+      $property: 'number',
+      $propertyPath: 'number',
+      $response: null,
+      $uid: 'number-externalResult-0',
+      $validator: '$externalResults'
+    }
+
+    it('saves external results, by changing individual properties, using `$model` to track changes', async () => {
       const validation = {
         number: { isEven }
       }
-      const { vm } = await createOldApiSimpleWrapper(validation, { number: 1, vuelidateExternalResults: { number: '' } })
+      const vuelidateExternalResults = { number: '' }
+
+      const { vm } = await createOldApiSimpleWrapper(validation, { number: 1, vuelidateExternalResults })
 
       vm.v.$touch()
-      expect(vm.vuelidateExternalResults).toEqual({ number: '' })
+      expect(vm.vuelidateExternalResults).toEqual(vuelidateExternalResults)
 
       expect(vm.v).toHaveProperty('number', expect.any(Object))
       expect(vm.v.number.$externalResults).toEqual([])
       // set an external validation result
       vm.vuelidateExternalResults.number = ['foo']
       // assert
-      const externalErrorObject = {
-        $message: 'foo',
-        $params: {},
-        $pending: false,
-        $property: 'number',
-        $propertyPath: 'number',
-        $response: null,
-        $uid: 'number-0',
-        $validator: '$externalResults'
-      }
       expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$silentErrors).toHaveLength(2)
       expect(vm.v.number.$silentErrors).toContainEqual(externalErrorObject)
       vm.v.number.$model = 2
       await nextTick()
+      // assert that changing `$model` resets the $externalResults
+      expect(vm.v.number.$error).toBe(false)
+      expect(vm.v.number.$externalResults).toHaveLength(0)
+      // add back the externalError
+      vm.vuelidateExternalResults.number = 'foo'
+      // assert the error is back
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$silentErrors).toHaveLength(1)
       expect(vm.v.number.$silentErrors).toEqual([externalErrorObject])
+      expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
       vm.vuelidateExternalResults.number = []
       expect(vm.v.number.$error).toBe(false)
       expect(vm.v.number.$silentErrors).toEqual([])
     })
 
-    it('works by replacing the entire external state, with pre-definition', async () => {
+    it('works by replacing the entire external state, with pre-definition, using `$autoDirty` to track changes', async () => {
       const validation = {
         number: { isEven }
       }
       const vuelidateExternalResults = { number: '' }
-      const { vm } = await createOldApiSimpleWrapper(validation, { number: 1, vuelidateExternalResults })
+      const { vm } = await createOldApiSimpleWrapper(validation, { number: 1, vuelidateExternalResults }, { $autoDirty: true })
 
       vm.v.$touch()
-      expect(vm.vuelidateExternalResults).toEqual({ number: '' })
+      expect(vm.vuelidateExternalResults).toEqual(vuelidateExternalResults)
 
       expect(vm.v).toHaveProperty('number', expect.any(Object))
       expect(vm.v.number.$externalResults).toEqual([])
       // set an external validation result
       Object.assign(vm.vuelidateExternalResults, { number: ['foo'] })
       // assert
-      const externalErrorObject = {
-        $message: 'foo',
-        $params: {},
-        $pending: false,
-        $property: 'number',
-        $propertyPath: 'number',
-        $response: null,
-        $uid: 'number-0',
-        $validator: '$externalResults'
-      }
       expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$silentErrors).toHaveLength(2)
       expect(vm.v.number.$silentErrors).toContainEqual(externalErrorObject)
-      vm.v.number.$model = 2
+      vm.number = 2
       await nextTick()
+      // assert the externalResults was reset
+      expect(vm.v.number.$error).toBe(false)
+      expect(vm.v.number.$externalResults).toHaveLength(0)
+      // revert the external results error
+      Object.assign(vm.vuelidateExternalResults, { number: ['foo'] })
+      await nextTick()
+      // assert errors are visible again
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$silentErrors).toHaveLength(1)
       expect(vm.v.number.$silentErrors).toEqual([externalErrorObject])
@@ -393,14 +400,8 @@ describe('OptionsAPI validations', () => {
       // trigger again
       Object.assign(vm.vuelidateExternalResults, { number: ['bar'] })
       expect(vm.v.number.$externalResults).toEqual([{
-        $message: 'bar',
-        $params: {},
-        $pending: false,
-        $property: 'number',
-        $propertyPath: 'number',
-        $response: null,
-        $uid: 'number-0',
-        $validator: '$externalResults'
+        ...externalErrorObject,
+        $message: 'bar'
       }])
     })
   })

--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -261,6 +261,21 @@ describe('useVuelidate', () => {
       expect(vm.v.number).toHaveProperty('$invalid', false)
     })
 
+    it('should update the `$dirty` state to `true`, even after `$reset`', async () => {
+      const { state, validations } = simpleValidation()
+      const { vm } = await createSimpleWrapper(validations, state, { $autoDirty: true })
+      state.number.value = 10
+      await nextTick()
+      expect(vm.v.number.$error).toBe(false)
+      expect(vm.v.number.$dirty).toBe(true)
+      vm.v.$reset()
+      expect(vm.v.number.$dirty).toBe(false)
+      state.number.value = 1
+      await nextTick()
+      expect(vm.v.number.$error).toBe(true)
+      expect(vm.v.number.$dirty).toBe(true)
+    })
+
     it('when used at root with plain object, should update the $dirty state', async () => {
       const number = ref(1)
       const { vm } = await createSimpleWrapper({ number: { isEven } }, { number }, { $autoDirty: true })
@@ -509,6 +524,10 @@ describe('useVuelidate', () => {
       expect(vm.v.$dirty).toBe(true)
       expect(vm.v.$error).toBe(true)
       expect(vm.v.number.$error).toBe(true)
+      number.value = 0
+      await nextTick()
+      expect(vm.v.$error).toBe(false)
+      expect(vm.v.number.$error).toBe(false)
     })
   })
 
@@ -979,7 +998,7 @@ describe('useVuelidate', () => {
       expect(vm.v.noPromise.syncValidator).toHaveProperty('$response', errorObject)
     })
 
-    it('handles throwing from async validators', async () => {
+    it('handles rejecting an async validators', async () => {
       const { errorObject, validations, state } = simpleErrorValidation()
       const { vm } = await createSimpleWrapper(validations, state)
       vm.v.withPromise.$touch()
@@ -987,6 +1006,28 @@ describe('useVuelidate', () => {
       expect(vm.v.withPromise.$error).toBe(true)
       // assert the `$response` is saved
       expect(vm.v.withPromise.asyncValidator).toHaveProperty('$response', errorObject)
+    })
+
+    it('handles throwing inside async validators', async () => {
+      const state = reactive({
+        name: ''
+      })
+      const error = new Error('FOO')
+
+      const validations = {
+        withPromise: {
+          asyncValidator: withAsync(() => {
+            throw error
+          })
+        }
+      }
+
+      const { vm } = await createSimpleWrapper(validations, state)
+      vm.v.withPromise.$touch()
+      await nextTick()
+      expect(vm.v.withPromise.$error).toBe(true)
+      // assert the `$response` is saved
+      expect(vm.v.withPromise.asyncValidator).toHaveProperty('$response', error)
     })
 
     it('handles a mix of async and sync validators, that throw errors', async () => {
@@ -1379,32 +1420,43 @@ describe('useVuelidate', () => {
   })
 
   describe('$externalResults', () => {
-    it('accepts a ref object, with a string as an error', async () => {
+    let message = 'External Error'
+    let message2 = 'External Error 2'
+
+    it('accepts a ref object, with a string as an error, using `$autoDirty` to track changes', async () => {
       const $externalResults = ref({})
       const { state, validations } = simpleValidation()
-      const { vm } = await createSimpleWrapper(validations, state, { $externalResults })
+      const { vm } = await createSimpleWrapper(validations, state, { $externalResults, $autoDirty: true })
       shouldBeInvalidValidationObject({ v: vm.v.number, property: 'number', validatorName: 'isEven' })
       vm.v.$touch()
       $externalResults.value = {
-        number: 'External Error'
+        number: message
       }
       let externalErrorObject = {
-        $message: 'External Error',
+        $message: message,
         $params: {},
         $pending: false,
         $property: 'number',
         $propertyPath: 'number',
         $response: null,
-        $uid: 'number-0',
+        $uid: 'number-externalResult-0',
         $validator: '$externalResults'
       }
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
       expect(vm.v.number.$silentErrors).toHaveLength(2)
       expect(vm.v.number.$silentErrors).toContainEqual(externalErrorObject)
-      // remove the validation error
+      // remove the validation errors
       state.number.value = 2
       await nextTick()
+      // assert there are no errors
+      expect(vm.v.number.$error).toBe(false)
+      expect(vm.v.number.$silentErrors).toHaveLength(0)
+      expect(vm.v.number.$externalResults).toHaveLength(0)
+      // re-add the external validation error
+      $externalResults.value.number = message
+      await nextTick()
+      // assert error is added where necessary
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$silentErrors).toHaveLength(1)
       expect(vm.v.number.$silentErrors).toEqual([externalErrorObject])
@@ -1412,34 +1464,34 @@ describe('useVuelidate', () => {
       expect(vm.v.number.$error).toBe(false)
     })
 
-    it('accepts a ref object, with an array as an error, without pre-definition', async () => {
+    it('accepts a ref object, with an array as an error, without pre-definition, using `$model` to track changes', async () => {
       const $externalResults = ref({})
       const { state, validations } = simpleValidation()
       const { vm } = await createSimpleWrapper(validations, state, { $externalResults })
       shouldBeInvalidValidationObject({ v: vm.v.number, property: 'number', validatorName: 'isEven' })
       vm.v.$touch()
       $externalResults.value = {
-        number: ['External Error 1', 'External Error 2']
+        number: [message, message2]
       }
       let externalErrorObjectOne = {
-        $message: 'External Error 1',
+        $message: message,
         $property: 'number',
         $propertyPath: 'number',
         $validator: '$externalResults',
         $params: {},
         $pending: false,
         $response: null,
-        $uid: 'number-0'
+        $uid: 'number-externalResult-0'
       }
       let externalErrorObjectTwo = {
-        $message: 'External Error 2',
+        $message: message2,
         $property: 'number',
         $propertyPath: 'number',
         $validator: '$externalResults',
         $params: {},
         $pending: false,
         $response: null,
-        $uid: 'number-1'
+        $uid: 'number-externalResult-1'
       }
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$externalResults).toEqual([externalErrorObjectOne, externalErrorObjectTwo])
@@ -1447,8 +1499,16 @@ describe('useVuelidate', () => {
       expect(vm.v.number.$silentErrors).toContainEqual(externalErrorObjectOne)
       expect(vm.v.number.$silentErrors).toContainEqual(externalErrorObjectTwo)
       // remove the validation error
-      state.number.value = 2
+      vm.v.number.$model = 2
       await nextTick()
+      // assert there are no errors
+      expect(vm.v.number.$error).toBe(false)
+      expect(vm.v.number.$errors).toHaveLength(0)
+      // re-add the external error
+      $externalResults.value = {
+        number: [message, message2]
+      }
+      // assert we have errors again
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$silentErrors).toHaveLength(2)
       expect(vm.v.number.$silentErrors).toEqual([externalErrorObjectOne, externalErrorObjectTwo])
@@ -1456,32 +1516,42 @@ describe('useVuelidate', () => {
       expect(vm.v.number.$error).toBe(false)
     })
 
-    it('accepts a reactive object, with pre-defined properties', async () => {
+    it('accepts a reactive object, with pre-defined properties, using `$model` to track changes', async () => {
       const $externalResults = reactive({ number: '' })
       const { state, validations } = simpleValidation()
       const { vm } = await createSimpleWrapper(validations, state, { $externalResults })
       shouldBeInvalidValidationObject({ v: vm.v.number, property: 'number', validatorName: 'isEven' })
       vm.v.$touch()
-      $externalResults.number = 'External Error'
+      $externalResults.number = message
 
       let externalErrorObject = {
-        $message: 'External Error',
+        $message: message,
         $property: 'number',
         $propertyPath: 'number',
         $validator: '$externalResults',
         $params: {},
         $pending: false,
         $response: null,
-        $uid: 'number-0'
+        $uid: 'number-externalResult-0'
       }
 
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
       expect(vm.v.number.$silentErrors).toHaveLength(2)
       expect(vm.v.number.$silentErrors).toContainEqual(externalErrorObject)
-      // remove the validation error
-      state.number.value = 2
+      // remove the validation errors
+      vm.v.number.$model = 2
       await nextTick()
+      // assert that `$model` clears out external errors
+      expect(vm.v.number.$error).toBe(false)
+      // assert there are no more errors
+      expect(vm.v.number.$silentErrors).toHaveLength(0)
+      // assert there are no external errors
+      expect(vm.v.number.$externalResults).toHaveLength(0)
+
+      // add an external error back
+      $externalResults.number = message
+      // assert there is an error again
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$silentErrors).toHaveLength(1)
       expect(vm.v.number.$silentErrors).toEqual([externalErrorObject])
@@ -1492,7 +1562,7 @@ describe('useVuelidate', () => {
       expect(vm.v.number.$silentErrors).toEqual([])
 
       // test what happens after we clear
-      $externalResults.number = 'External Error'
+      $externalResults.number = message
 
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
@@ -1505,55 +1575,75 @@ describe('useVuelidate', () => {
       const { state, validations } = nestedRefObjectValidation()
       const { vm } = await createSimpleWrapper(validations, state, { $externalResults })
       vm.v.$touch()
+
       $externalResults.value = {
         level1: {
-          child: ['External Error 1', 'External Error 2']
+          child: [message, message2]
         }
       }
+
       const externalErrorObjectOne = {
-        $message: 'External Error 1',
+        $message: message,
         $property: 'child',
         $propertyPath: 'level1.child',
         $validator: '$externalResults',
         $params: {},
         $pending: false,
         $response: null,
-        $uid: 'level1.child-0'
+        $uid: 'level1.child-externalResult-0'
       }
       const externalErrorObjectTwo = {
-        $message: 'External Error 2',
+        $message: message2,
         $property: 'child',
         $propertyPath: 'level1.child',
         $validator: '$externalResults',
         $params: {},
         $pending: false,
         $response: null,
-        $uid: 'level1.child-1'
+        $uid: 'level1.child-externalResult-1'
       }
 
       expect(vm.v.$errors).toHaveLength(3)
       expect(vm.v.$errors).toEqual(expect.arrayContaining([externalErrorObjectOne, externalErrorObjectTwo]))
+
+      // update the model of a child, keeping it invalid
+      vm.v.level1.child.$model = 3
+      await nextTick()
+      expect(vm.v.$error).toBe(true)
+      expect(vm.v.$errors).toHaveLength(1)
+      expect(vm.v.level1.child.$externalResults).toHaveLength(0)
+      $externalResults.value = {
+        level1: {
+          child: [message, message2]
+        }
+      }
+      await nextTick()
+      expect(vm.v.level1.child.$externalResults).toHaveLength(2)
+      vm.v.level1.child.$model = 2
+      await nextTick()
+      expect(vm.v.level1.child.$externalResults).toHaveLength(0)
     })
 
     // reactive does not work in Vue 2, without pre-defining your keys.
-    ifVue3('accepts a reactive object, without pre-definition', async () => {
+    ifVue3('accepts a reactive object, without pre-definition, setting `$autoDirty` to `false`, to make sure we dont reset unexpectedly', async () => {
       const $externalResults = reactive({})
       const { state, validations } = simpleValidation()
-      const { vm } = await createSimpleWrapper(validations, state, { $externalResults })
+      const { vm } = await createSimpleWrapper(validations, state, { $externalResults, $autoDirty: false })
       shouldBeInvalidValidationObject({ v: vm.v.number, property: 'number', validatorName: 'isEven' })
       vm.v.$touch()
-      $externalResults.number = 'External Error'
+      $externalResults.number = message
 
       let externalErrorObject = {
-        $message: 'External Error',
+        $message: message,
         $property: 'number',
         $propertyPath: 'number',
         $validator: '$externalResults',
         $params: {},
         $pending: false,
         $response: null,
-        $uid: 'number-0'
+        $uid: 'number-externalResult-0'
       }
+      // assert there is an error
       expect(vm.v.number.$error).toBe(true)
       expect(vm.v.number.$externalResults).toEqual([externalErrorObject])
       expect(vm.v.number.$silentErrors).toHaveLength(2)

--- a/packages/vuelidate/test/unit/utils.js
+++ b/packages/vuelidate/test/unit/utils.js
@@ -18,9 +18,10 @@ export const createSimpleComponent = (getVuelidateResults, state) => ({
   }
 })
 
-export const createOldApiSimpleComponent = (validations, state, config) => ({
+export const createOldApiSimpleComponent = (validations, state, validationsConfig) => ({
   name: 'childComp',
   validations,
+  validationsConfig,
   setup () {
     return { v: useVuelidate() }
   },

--- a/scripts/swap-vue.js
+++ b/scripts/swap-vue.js
@@ -10,6 +10,17 @@ const version = Number(process.argv[2]) || 3
 useVueVersion(version)
 
 function useVueVersion (version) {
+  if (!fs.existsSync(DefaultVue)) {
+    console.log('There is no default Vue version, finding it')
+    if (version === 2 && fs.existsSync(Vue3)) {
+      rename(Vue3, DefaultVue)
+      console.log('Renamed "vue3" to "vue"')
+    } else {
+      rename(Vue2, DefaultVue)
+      console.log('Renamed "vue2" to "vue"')
+    }
+  }
+
   if (version === 3 && fs.existsSync(Vue3)) {
     rename(DefaultVue, Vue2)
     rename(Vue3, DefaultVue)


### PR DESCRIPTION
## Summary

Automatically resets the `$externalResults` key for a changed property, when using `$autoDirty` or `$model`. closes #891 

This should make the `$clearExternalResults` method unnecessary, as the user would probably update the field before submitting again.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
