### PR TITLE
fix #917 add type for validator function with VM as second parameter

### DIFF
--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -40,22 +40,37 @@ export interface ValidatorResponse {
   [key: string]: any
 }
 
-export type ValidatorFn <T = unknown> = (value: T) => boolean | ValidatorResponse | Promise<boolean | ValidatorResponse>;
+export type ValidatorFn<T = unknown, V = unknown> =
+  | ValidatorFnSimple<T>
+  | ValidatorFnWithVm<T, V>
 
-export interface ValidationRuleWithoutParams <T = unknown> {
-  $validator: ValidatorFn<T>
+export type ValidatorFnSimple <T = unknown> = (value: T) => boolean | ValidatorResponse | Promise<boolean | ValidatorResponse>;
+
+export type ValidatorFnWithVm<T = unknown, V = unknown> = (
+  value: T,
+  vm: V
+) => boolean | ValidatorResponse | Promise<boolean | ValidatorResponse>
+
+export interface ValidationRuleWithoutParams <T = unknown, V = unknown> {
+  $validator: ValidatorFn<T, V>
   $message?: string | Ref<string> | (() => string)
 }
 
-export interface ValidationRuleWithParams<P extends object = object, T = unknown> {
-  $validator: ValidatorFn<T>
+export interface ValidationRuleWithParams<P extends object = object, T = unknown, V = unknown> {
+  $validator: ValidatorFn<T, V>
   $message: (input: { $params: P }) => string
   $params: P
 }
 
-export type ValidationRule <T = unknown> = ValidationRuleWithParams<any, T> | ValidationRuleWithoutParams<T> | ValidatorFn<T>;
+export type ValidationRule<T = unknown, V = unknown> =
+  | ValidationRuleWithParams<any, T>
+  | ValidationRuleWithoutParams<T>
+  | ValidatorFn<T, V>
 
-type ValidationRuleCollection <T = unknown> = Record<string, ValidationRule<T>>;
+type ValidationRuleCollection<T = unknown, V = unknown> = Record<
+  string,
+  ValidationRule<T, V>
+>
 
 export interface ValidationArgs {
   [K: string]: ValidationRule | ValidationArgs


### PR DESCRIPTION
add type for validator function with vm as second parameter

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
