### PR TITLE
feat(core): add the $validate method to every validation leaf, closes #861

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,8 @@ module.exports = {
     node: true
   },
   parserOptions: {
-    parser: '@babel/eslint-parser'
+    parser: '@babel/eslint-parser',
+    requireConfigFile: false
   },
   extends: [
     'plugin:vue/recommended',

--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -112,6 +112,7 @@ type BaseValidation <
   // const validationMethods
   readonly $touch: () => void
   readonly $reset: () => void
+  readonly $validate: () => Promise<boolean>
 };
 
 type NestedValidations <Vargs extends ValidationArgs = ValidationArgs, T = unknown> = {
@@ -127,7 +128,6 @@ type NestedValidations <Vargs extends ValidationArgs = ValidationArgs, T = unkno
 };
 
 interface ChildValidations {
-  readonly $validate: () => Promise<boolean>
   readonly $getResultsForChild: (key: string) => (BaseValidation & ChildValidations) | undefined
   readonly $clearExternalResults: () => void
 }

--- a/packages/vuelidate/src/index.js
+++ b/packages/vuelidate/src/index.js
@@ -95,7 +95,7 @@ export function useVuelidate (validations, state, globalConfig = {}) {
   }
   let { $registerAs, $scope = CollectFlag.COLLECT_ALL, $stopPropagation, $externalResults } = globalConfig
 
-  let instance = getCurrentInstance()
+  const instance = getCurrentInstance()
 
   const componentOptions = instance
     ? (isVue3 ? instance.type : instance.proxy.$options)

--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -715,14 +715,18 @@ describe('useVuelidate', () => {
       expect(await vm.v.$validate()).toBe(true)
     })
 
-    it('is only present at the top level', async () => {
+    it('is allows validating a child leaf only', async () => {
       const { state, validations } = nestedReactiveObjectValidation()
       const { vm } = await createSimpleWrapper(validations, state)
 
       expect(vm.v).toHaveProperty('$validate', expect.any(Function))
-      expect(vm.v.level0).not.toHaveProperty('$validate')
-      expect(vm.v.level1).not.toHaveProperty('$validate')
-      expect(vm.v.level1.level2).not.toHaveProperty('$validate')
+      expect(vm.v.level0).toHaveProperty('$validate')
+      expect(vm.v.level1).toHaveProperty('$validate')
+      expect(await vm.v.level1.$validate()).toBe(false)
+      expect(vm.v.level1.$dirty).toBe(true)
+      expect(vm.v.level1.level2.$dirty).toBe(true)
+      expect(vm.v.level1.level2.child.$dirty).toBe(true)
+      expect(vm.v.level0.$dirty).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Summary

Adds the `$validate` method to every validation leaf, in order to allow for validation per form.

Closes #861

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
