### PR TITLE
feat(core): allow passing configs to OptionsApi directly in `useVuelidate`, closes #922

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ export default {
 ## Providing global config to your Vuelidate instance
 
 You can provide global configs to your Vuelidate instance using the third parameter of `useVuelidate` or by using the `validationsConfig`. These
-config options are used to change some core Vuelidate functionality, like `autoDirty`, `lazy`, `scope` and more. Learn all about them
+config options are used to change some core Vuelidate functionality, like `$autoDirty`, `$lazy`, `$scope` and more. Learn all about them
 in [Validation Configuration](https://vuelidate-next.netlify.app/api.html#validation-configuration).
 
 ### Config with Options API

--- a/packages/docs/src/advanced_usage.md
+++ b/packages/docs/src/advanced_usage.md
@@ -390,8 +390,9 @@ export default {
 
 :::tip
 **Note:** You can pass validation configs as a single parameter to `useVuelidate`
+
 - [Passing a single parameter to useVuelidate](#passing-a-single-parameter-to-usevuelidate)
-:::
+  :::
 
 ## Returning extra data from validators
 
@@ -429,13 +430,15 @@ export default {
 
 ## Providing global config to your Vuelidate instance
 
-You can provide global configs to your Vuelidate instance using the third parameter of `useVuelidate` or by using the `validationsConfig`. These
-config options are used to change some core Vuelidate functionality, like `autoDirty`, `lazy`, `scope` and more. Learn all about them
+You can provide configurations to your Vuelidate instance using the third parameter of `useVuelidate` or by using the `validationsConfig` for Options
+API. These config options are used to change some core Vuelidate functionality, like `$autoDirty`, `$lazy`, `$scope` and more. Read about each one
 in [Validation Configuration](./api/configuration.md).
 
 ### Config with Options API
 
-If you prefer the Options API, you can specify a `validationConfig` object, that Vuelidate will read configs from.
+#### Using `validationConfig`
+
+If you are using the Options API, you can specify a `validationConfig` object, that Vuelidate will read configs from.
 
 ```vue
 
@@ -457,9 +460,32 @@ export default {
 </script>
 ```
 
+#### Using the config object of useVuelidate
+
+An alternative is to use the first parameter of `useVuelidate` to pass a config object,
+see [Passing a single parameter to useVuelidate](#passing-a-single-parameter-to-usevuelidate) for more info.
+
+```vue
+
+<script>
+import { useVuelidate } from '@vuelidate/core'
+
+export default {
+  data () {
+    return { ...state }
+  },
+  validations () {
+    return { ...validations }
+  },
+  setup: () => ({ v$: useVuelidate({ $lazy: true, $autoDirty: true, $scope: 'foo' }) }),
+}
+</script>
+```
+
 ### Config with Composition API
 
-When using the Composition API, you can pass your configuration object as the third parameter to `useVuelidate`.
+When using the Composition API, you can pass your configuration object as the third parameter to `useVuelidate`, or as the first one, if the component
+is just a collector, see [Passing a single parameter to useVuelidate](#passing-a-single-parameter-to-usevuelidate).
 
 ```js
 import { reactive } from 'vue' // or '@vue/composition-api' in Vue 2.x
@@ -480,7 +506,7 @@ export default {
 #### Passing a single parameter to useVuelidate
 
 A common scenario is to call `useVuelidate()` without passing any state or validations, usually in validation collector components. In such cases you
-can pass global configs like `$scope` or `$stopPropagation` as a single parameter to `useVuelidate()`.
+can pass global configs like `$scope`, `$stopPropagation` as a single parameter to `useVuelidate()`.
 
 ```js
 import { useVuelidate } from '@vuelidate/core'
@@ -489,7 +515,7 @@ import FormB from '@/componnets/FormB'
 
 export default {
   components: { FormA, FormB },
-  setup: () => ({ v$: useVuelidate({ $stopPropagation: true }) })
+  setup: () => ({ v$: useVuelidate({ $stopPropagation: true, $scope: 'foo' }) })
 }
 ```
 
@@ -532,9 +558,12 @@ return { v, validate }
 
 ### External results with Options API
 
-When using the Options API, you just need to define a `vuelidateExternalResults` data property, and assign the errors to it.
+When using the Options API, you can either define a `vuelidateExternalResults` data property, and assign the errors to it. You can also pass
+an `$externalResults` property to the `useVuelidate` config object.
 
 It is a good practice to pre-define your external results keys, to match your form structure, otherwise Vue may have a hard time tracking changes.
+
+#### Using `vuelidateExternalResults` property
 
 ```js
 export default {
@@ -562,13 +591,31 @@ export default {
 }
 ```
 
-To clear out the external results, you can again, use the `$clearExternalResults()` method
+#### Using `$externalResults` config
 
 ```js
-async function validate () {
-  this.$v.value.$clearExternalResults()
-  // perform validations
-  const result = await this.runAsyncValidators()
+export default {
+  data: () => ({ foo: '' }),
+  validations () {
+    return {
+      foo: { someValidation }
+    }
+  },
+  setup: () => {
+    const externalResults = ref()
+    return {
+      externalResults,
+      v: useVuelidate({ $externalResults: externalResults })
+    }
+  },
+  methods: {
+    validate () {
+      // perform validations
+      const errors = { foo: ['Error one', 'Error Two'] }
+      // merge the errors into the validation results
+      Object.assign(this.externalResults, errors)
+    }
+  }
 }
 ```
 

--- a/packages/docs/src/api/configuration.md
+++ b/packages/docs/src/api/configuration.md
@@ -50,3 +50,24 @@
 
   Allow assigning a custom component registration name to a Vuelidate instance. This is used when a validation is registered in a parent validation
   form.
+
+## $externalResults
+
+* **Type:** `ServerErrors | Ref<ServerErrors> | UnwrapRef<ServerErrors>`
+
+* **Usage:**
+
+  Pass an object, matching your state, that holds external validation errors. These can be from a backend validations or something else.
+
+* **Example:**
+
+```js
+const $externalResults = reactive({})
+const state = { number: 0 }
+const validations = { number: { required } }
+const v$ = useVuelidate(validations, state, { $externalResults })
+// some other logic
+$externalResults.number = ['One error', 'Two Errors']
+// setting a value in `$externalResults` for the `number` property would cause that property to become invalid.
+expect(v$.value.number.$invalid).toBe(true)
+```

--- a/packages/vuelidate/README.md
+++ b/packages/vuelidate/README.md
@@ -97,7 +97,7 @@ export default {
 ## Providing global config to your Vuelidate instance
 
 You can provide global configs to your Vuelidate instance using the third parameter of `useVuelidate` or by using the `validationsConfig`. These
-config options are used to change some core Vuelidate functionality, like `autoDirty`, `lazy`, `scope` and more. Learn all about them
+config options are used to change some core Vuelidate functionality, like `$autoDirty`, `$lazy`, `$scope` and more. Learn all about them
 in [Validation Configuration](https://vuelidate-next.netlify.app/api.html#validation-configuration).
 
 ### Config with Options API

--- a/packages/vuelidate/src/index.js
+++ b/packages/vuelidate/src/index.js
@@ -75,6 +75,8 @@ function nestedValidations ({ $scope }) {
  * @property {String | Number | Symbol} [$scope] - A scope to limit child component registration
  * @property {Boolean} [$stopPropagation] - Tells a Vue component to stop sending its results up to the parent
  * @property {Ref<Object>} [$externalResults] - External error messages, like from server validation.
+ * @property {Boolean} [$autoDirty] - Should the form watch for state changed, and automatically set `$dirty` to true.
+ * @property {Boolean} [$lazy] - Should the validations be lazy, and run only after they are dirty
  */
 
 /**
@@ -150,12 +152,12 @@ export function useVuelidate (validations, state, globalConfig = {}) {
             resultsCache,
             globalConfig,
             instance: instance.proxy,
-            externalResults: instance.proxy.vuelidateExternalResults
+            externalResults: $externalResults || instance.proxy.vuelidateExternalResults
           })
         }, { immediate: true })
     })
 
-    globalConfig = componentOptions.validationsConfig || {}
+    globalConfig = componentOptions.validationsConfig || globalConfig
   } else {
     const validationsWatchTarget = isRef(validations) || isProxy(validations)
       ? validations

--- a/packages/vuelidate/test/unit/specs/optionsApi.spec.js
+++ b/packages/vuelidate/test/unit/specs/optionsApi.spec.js
@@ -1,4 +1,4 @@
-import { ref, nextTick } from 'vue-demi'
+import { ref, nextTick, h } from 'vue-demi'
 import { isEven, isOdd } from '../validators.fixture'
 import {
   createOldApiSimpleWrapper,
@@ -15,6 +15,7 @@ import {
 } from '../validations.fixture'
 import { flushPromises, mount } from '../test-utils'
 import withAsync from '@vuelidate/validators/src/utils/withAsync'
+import { useVuelidate } from '../../../src'
 
 describe('OptionsAPI validations', () => {
   it('should have a `v` key defined if used', async () => {
@@ -138,12 +139,12 @@ describe('OptionsAPI validations', () => {
       const childState = vm.v.$getResultsForChild(childValidationRegisterName)
       expect(childState).toHaveProperty('$errors')
       expect(childState.$errors).toContainEqual({
-        '$message': '',
-        '$params': {},
-        '$pending': false,
-        '$property': 'number',
-        '$propertyPath': 'number',
-        '$validator': 'isEven',
+        $message: '',
+        $params: {},
+        $pending: false,
+        $property: 'number',
+        $propertyPath: 'number',
+        $validator: 'isEven',
         $response: false,
         $uid: 'number-isEven'
       })
@@ -405,6 +406,33 @@ describe('OptionsAPI validations', () => {
         $message: 'bar'
       }])
     })
+
+    it('allows passing externalResults in the setup as a ref', async () => {
+      const $externalResults = ref({})
+      const Component = {
+        name: 'childComp',
+        validations: () => ({
+          number: { isEven }
+        }),
+        setup: () => ({ v: useVuelidate({ $externalResults }) }),
+        data () {
+          return {
+            number: 1
+          }
+        },
+        render () {
+          return h('pre', {}, JSON.stringify(this.v))
+        }
+      }
+      const wrapper = mount(Component)
+      await wrapper.vm.$nextTick()
+      expect(wrapper.vm.v.number.$invalid).toBe(true)
+      wrapper.vm.v.number.$model = 2
+      expect(wrapper.vm.v.number.$invalid).toBe(false)
+      $externalResults.value.number = 'Invalid External'
+      expect(wrapper.vm.v.number.$invalid).toBe(true)
+      expect(wrapper.vm.v.number.$externalResults).toHaveLength(1)
+    })
   })
 
   describe('deep changes in state', () => {
@@ -454,6 +482,35 @@ describe('OptionsAPI validations', () => {
       await vm.$nextTick()
 
       expect(vm.v.level1.level2.child).toHaveProperty('$invalid', true)
+    })
+  })
+
+  describe('validationsConfig', () => {
+    it('allows passing `validationsConfig` via the useVuelidate first parameter', async () => {
+      const validator = jest.fn((v) => v === 2)
+      const Component = {
+        name: 'childComp',
+        validations: () => ({
+          number: { validator }
+        }),
+        setup: () => ({ v: useVuelidate({ $autoDirty: true, $lazy: true }) }),
+        data () {
+          return {
+            number: 1
+          }
+        },
+        render () {
+          return h('pre', {}, JSON.stringify(this.v))
+        }
+      }
+      const wrapper = mount(Component)
+      await wrapper.vm.$nextTick()
+      expect(validator).not.toHaveBeenCalled()
+      expect(wrapper.vm.v.number.$dirty).toBe(false)
+      wrapper.vm.number = 2
+      await wrapper.vm.$nextTick()
+      expect(validator).toHaveBeenCalledTimes(1)
+      expect(wrapper.vm.v.number.$dirty).toBe(true)
     })
   })
 })


### PR DESCRIPTION
## Summary

This PR allows for `useVuelidate` to accept a config object, when used in the OptionsAPI, closes #922 

This should aid in providing reactive data, like `$externalResults` more easily.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
