### PR TITLE
fix: forEach helper throwing, when state has no validator, closes #931 

### DIFF
--- a/packages/validators/src/utils/__tests__/forEach.spec.js
+++ b/packages/validators/src/utils/__tests__/forEach.spec.js
@@ -35,6 +35,51 @@ describe('forEach', () => {
     expect(required).toHaveBeenCalledWith('Foo')
   })
 
+  it('does not throw, if a property does not have a validator', () => {
+    expect(forEach(rules).$validator([{
+      name: '',
+      surname: '' // surname has no validator, but it should not cause errors
+    }])).toEqual({
+      $data: [
+        {
+          name: {
+            isFoo: false,
+            required: false
+          },
+          surname: {}
+        }
+      ],
+      $errors: [
+        {
+          name: [
+            {
+              $message: 'Not Foo',
+              $model: '',
+              $params: {},
+              $pending: false,
+              $property: 'name',
+              $response: false,
+              $validator: 'isFoo'
+            },
+            {
+              $message: 'Is Required',
+              $model: '',
+              $params: {},
+              $pending: false,
+              $property: 'name',
+              $response: false,
+              $validator: 'required'
+            }
+          ],
+          surname: []
+        }
+      ],
+      $valid: false
+    })
+    expect(isFoo).toHaveBeenCalledTimes(1)
+    expect(required).toHaveBeenCalledTimes(1)
+  })
+
   it('passes the correct this context', () => {
     const context = {
       foo: 'bar'

--- a/packages/validators/src/utils/forEach.js
+++ b/packages/validators/src/utils/forEach.js
@@ -8,7 +8,7 @@ export default function forEach (validators) {
         // go over each property
         const collectionEntryResult = Object.entries(object).reduce((all, [key, $model]) => {
           // get the validators for this property
-          const innerValidators = validators[key]
+          const innerValidators = validators[key] || {}
           // go over each validator and run it
           const propertyResult = Object.entries(innerValidators).reduce((all, [validatorName, currentValidator]) => {
             // extract the validator. Supports simple and extended validators.


### PR DESCRIPTION
## Summary

Stops the forEach helper from throwing when there is no validator for a single property in the state it observes. closes #931 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
