### PR TITLE
Types for or/not/and, `ValidatorFn`, relax types (PR #903 + mods)

### DIFF
--- a/packages/validators/index.d.ts
+++ b/packages/validators/index.d.ts
@@ -47,8 +47,8 @@ export const sameAs: <E = unknown>(
 ) => ValidationRuleWithParams<{ equalTo: E, otherName: string }>;
 export const url: ValidationRuleWithoutParams;
 export const helpers: {
-  withParams: (params: object, validator: ValidationRule) => ValidationRuleWithParams
-  withMessage: (message: string | Function, validator: ValidationRule) => ValidationRuleWithParams
+  withParams: <T = unknown>(params: object, validator: ValidationRule<T>) => ValidationRuleWithParams
+  withMessage: <T = unknown>(message: string | ((params: MessageProps) => string), validator: ValidationRule<T>) => ValidationRuleWithParams
   req: Function
   len: Function
   regex: Function

--- a/packages/validators/index.d.ts
+++ b/packages/validators/index.d.ts
@@ -3,14 +3,14 @@ import {
   ValidationRuleWithParams,
   ValidationRule,
   ValidationArgs
-} from '@vuelidate/core'
+} from '@vuelidate/core';
 import { Ref } from 'vue-demi';
 
 // Rules
 export const alpha: ValidationRuleWithoutParams;
 export const alphaNum: ValidationRuleWithoutParams;
-export const and: (
-  ...validators: ValidationRule[]
+export const and: <T = unknown>(
+  ...validators: ValidationRule<T>[]
 ) => ValidationRuleWithoutParams;
 export const between: (
   min: number | Ref<number>,
@@ -32,23 +32,23 @@ export const minLength: (
 ) => ValidationRuleWithParams<{ length: number }>;
 export const minValue: (
   min: number | Ref<number> | string | Ref<string>
-) => ValidationRuleWithParams<{ min: number }>
-export const not: (validator: ValidationRule) => ValidationRuleWithoutParams
-export const numeric: ValidationRuleWithoutParams
-export const or: (
-  ...validators: ValidationRule[]
-) => ValidationRuleWithoutParams
-export const required: ValidationRuleWithoutParams
-export const requiredIf: (prop: boolean | string | (() => boolean | Promise<boolean>)) => ValidationRuleWithoutParams
-export const requiredUnless: (prop: boolean | string | (() => boolean | Promise<boolean>)) => ValidationRuleWithoutParams
+) => ValidationRuleWithParams<{ min: number }>;
+export const not: <T = unknown>(validator: ValidationRule<T>) => ValidationRuleWithoutParams;
+export const numeric: ValidationRuleWithoutParams;
+export const or: <T = unknown>(
+  ...validators: ValidationRule<T>[]
+) => ValidationRuleWithoutParams;
+export const required: ValidationRuleWithoutParams;
+export const requiredIf: (prop: boolean | string | (() => boolean | Promise<boolean>)) => ValidationRuleWithoutParams;
+export const requiredUnless: (prop: boolean | string | (() => boolean | Promise<boolean>)) => ValidationRuleWithoutParams;
 export const sameAs: <E = unknown>(
   equalTo: E,
   otherName?: string
 ) => ValidationRuleWithParams<{ equalTo: E, otherName: string }>;
 export const url: ValidationRuleWithoutParams;
 export const helpers: {
-  withParams: <T = unknown>(params: object, validator: ValidationRule<T>) => ValidationRuleWithParams
-  withMessage: <T = unknown>(message: string | ((params: MessageProps) => string), validator: ValidationRule<T>) => ValidationRuleWithParams
+  withParams: (params: object, validator: ValidationRule) => ValidationRuleWithParams
+  withMessage: (message: string | Function, validator: ValidationRule) => ValidationRuleWithParams
   req: Function
   len: Function
   regex: Function

--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -40,7 +40,7 @@ export interface ValidatorResponse {
   [key: string]: any
 }
 
-export type ValidatorFn <T = unknown> = (value: T) => boolean | ValidatorResponse | Promise<boolean | ValidatorResponse>;
+export type ValidatorFn <T = unknown> = (value: T, vm: Vue) => boolean | ValidatorResponse | Promise<boolean | ValidatorResponse>;
 
 export interface ValidationRuleWithoutParams <T = unknown> {
   $validator: ValidatorFn<T>

--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -40,22 +40,22 @@ export interface ValidatorResponse {
   [key: string]: any
 }
 
-export type ValidatorFn <T = unknown> = (value: T, vm: Vue) => boolean | ValidatorResponse | Promise<boolean | ValidatorResponse>;
+export type ValidatorFn <T = any, S = any> = (value: T, vm: Vue & S) => boolean | ValidatorResponse | Promise<boolean | ValidatorResponse>;
 
-export interface ValidationRuleWithoutParams <T = unknown> {
+export interface ValidationRuleWithoutParams <T = any> {
   $validator: ValidatorFn<T>
   $message?: string | Ref<string> | (() => string)
 }
 
-export interface ValidationRuleWithParams<P extends object = object, T = unknown> {
+export interface ValidationRuleWithParams<P extends object = object, T = any> {
   $validator: ValidatorFn<T>
   $message: (input: { $params: P }) => string
   $params: P
 }
 
-export type ValidationRule <T = unknown> = ValidationRuleWithParams<any, T> | ValidationRuleWithoutParams<T> | ValidatorFn<T>;
+export type ValidationRule <T = any> = ValidationRuleWithParams<any, T> | ValidationRuleWithoutParams<T> | ValidatorFn<T>;
 
-export type ValidationRuleCollection <T = unknown> = Record<string, ValidationRule<T>>;
+export type ValidationRuleCollection <T = any> = Record<string, ValidationRule<T>>;
 
 export interface ValidationArgs {
   [K: string]: ValidationRule | ValidationArgs


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

I do not expect this to be a breaking change for TypeScript users but I think that there is still room for improvement.

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This is a fork of #903 which appears to resolve #917 with the changes discussed in the original PR's comments. The goal of this modded version of the original PR is to unblock teams like mine that need typed `vm` and are unable to use explicitly typed `ValidatorFn`.

I still have not figured out a good dev setup for this library so I unfortunately have not tested it; however, I do not expect any of the changes to be problematic as all they're doing is adding some optional types and adding some generics.

The original PR by @victorgarciaesgi says:

```
Fellowing previous PR, I added more Typescript upgrades for validators.

and: support for type casting
or: support for type casting
not: support for type casting
ValidatorFn: added vm: Vue as second param to access current instance
```

In the comments, we agreed that `ValidatorFn`'s `vm` should be typed as the union between _some component-specific state_ and `Vue`, which is one of the changes made here. The other changes, swapping out `unknown` for `any`, works around an issue wherein the library has types that reference other types which default to `unknown`, effectively preventing users from declaring `ValidatorFn` as described in [this comment here](https://github.com/vuelidate/vuelidate/pull/903#discussion_r710268529). I think that `unknown` is probably the correct type for `ValidatorFn` but if and only if `useVuelidate` is able to extract appropriate types and feed them down the pipe internally. I'd be happy to try this if someone can help me get a good TypeScript dev flow working.

@victorgarciaesgi, I hope I did not overstep by jumping on this, thank you for your work. 🙏  @basti-n maybe you can eyeball this and weigh in?