### PR TITLE
fix(validators): add $invalid and $error to forEach

### DIFF
--- a/packages/validators/src/utils/__tests__/forEach.spec.js
+++ b/packages/validators/src/utils/__tests__/forEach.spec.js
@@ -44,7 +44,9 @@ describe('forEach', () => {
         {
           name: {
             isFoo: false,
-            required: false
+            required: false,
+            $invalid: true,
+            $error: true
           },
           surname: {}
         }
@@ -101,13 +103,17 @@ describe('forEach', () => {
         {
           name: {
             isFoo: false,
-            required: false
+            required: false,
+            $error: true,
+            $invalid: true
           }
         },
         {
           name: {
             isFoo: true,
-            required: true
+            required: true,
+            $error: false,
+            $invalid: false
           }
         }
       ],
@@ -284,6 +290,8 @@ describe('forEach', () => {
       }
     }).$validator([{ name: 'Bar' }, { name: 'Foo' }]).$data).toEqual([{
       name: {
+        $error: false,
+        $invalid: false,
         isFoo: {
           $valid: true,
           $data: 'Foo'
@@ -291,7 +299,9 @@ describe('forEach', () => {
       }
     }, {
       name: {
-        isFoo: true
+        isFoo: true,
+        $error: false,
+        $invalid: false
       }
     }])
   })

--- a/packages/validators/src/utils/forEach.js
+++ b/packages/validators/src/utils/forEach.js
@@ -6,9 +6,9 @@ export default function forEach (validators) {
       // go over the collection. It can be a ref as well.
       return unwrap(collection).reduce((previous, collectionItem) => {
         // go over each property
-        const collectionEntryResult = Object.entries(collectionItem).reduce((all, [key, $model]) => {
+        const collectionEntryResult = Object.entries(collectionItem).reduce((all, [property, $model]) => {
           // get the validators for this property
-          const innerValidators = validators[key] || {}
+          const innerValidators = validators[property] || {}
           // go over each validator and run it
           const propertyResult = Object.entries(innerValidators).reduce((all, [validatorName, currentValidator]) => {
             // extract the validator. Supports simple and extended validators.
@@ -19,6 +19,8 @@ export default function forEach (validators) {
             const $valid = unwrapValidatorResponse($response)
             // store the entire response for later
             all.$data[validatorName] = $response
+            all.$data.$invalid = !$valid || !!all.$data.$invalid
+            all.$data.$error = all.$data.$invalid
             // if not valid, get the $message
             if (!$valid) {
               let $message = currentValidator.$message || ''
@@ -35,7 +37,7 @@ export default function forEach (validators) {
               }
               // save the error object
               all.$errors.push({
-                $property: key,
+                $property: property,
                 $message,
                 $params,
                 $response,
@@ -51,8 +53,8 @@ export default function forEach (validators) {
             }
           }, { $valid: true, $data: {}, $errors: [] })
 
-          all.$data[key] = propertyResult.$data
-          all.$errors[key] = propertyResult.$errors
+          all.$data[property] = propertyResult.$data
+          all.$errors[property] = propertyResult.$errors
 
           return {
             $valid: all.$valid && propertyResult.$valid,


### PR DESCRIPTION
## Summary

Adds `$invalid` and `$error` to each property of the `forEach` helper. Thous should make it easier to know if an individual field is invalid or not.

```json5
{
   "$message":[
      [
         "Value is required"
      ]
   ],
   "$params":{
      
   },
   "$pending":false,
   "$invalid":true,
   "$response":{
      "$valid":false,
      "$data":[
         {
            "name":{
               "required":false,
               "$invalid":true, // <-- new
               "$error":true, //<-- new
               "minLength":true
            }
         }
      ],
      "$errors":[
        // some errors
      ]
   }
}
```

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
