### PR TITLE
fix(core): allow providing child results into multiple Vuelidate instances

### DIFF
--- a/packages/test-project/src/App.vue
+++ b/packages/test-project/src/App.vue
@@ -10,6 +10,7 @@
         <li><router-link to="/nested-ref">Nested Ref</router-link></li>
         <li><router-link to="/collection-validations">Collection Validations</router-link></li>
         <li><router-link to="/external-validations">External Validations</router-link></li>
+        <li><router-link to="/nested-validations-with-scopes">Nested Validations with Scopes</router-link></li>
       </ul>
     </div>
     <router-view />

--- a/packages/test-project/src/components/NestedValidationsWithScopes/ChildWithScope.vue
+++ b/packages/test-project/src/components/NestedValidationsWithScopes/ChildWithScope.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <div>child control</div>
+    <div :class="{ valid: !v$.$error && v$.$dirty, error: v$.$error }">
+      <input
+        v-model="v$.childNumber.$model"
+        type="text"
+      >
+    </div>
+  </div>
+</template>
+
+<script>
+import { reactive } from 'vue'
+import useVuelidate from '@vuelidate/core'
+import { required, minValue } from '@vuelidate/validators'
+
+export default {
+  name: 'ChildComponent',
+  setup () {
+    const childRules = {
+      childNumber: {
+        required,
+        minLength: minValue(5)
+      }
+    }
+    const childState = reactive({
+      childNumber: null
+    })
+
+    const v$ = useVuelidate(childRules, childState, {
+      $scope: 'form1',
+      $registerAs: 'ChildForm'
+    })
+
+    return { v$ }
+  }
+}
+</script>

--- a/packages/test-project/src/components/NestedValidationsWithScopes/ParentValidator.vue
+++ b/packages/test-project/src/components/NestedValidationsWithScopes/ParentValidator.vue
@@ -1,0 +1,112 @@
+<template>
+  <div>
+    <div class="row">
+      <div>
+        <div>v1$ control</div>
+        <div :class="{ valid: !v1$.$error && v1$.$dirty, error: v1$.$error }">
+          <input
+            v-model="v1$.number.$model"
+            type="text"
+          >
+        </div>
+        <div
+          v-for="(error, index) in v1$.number.$errors"
+          :key="index"
+        >
+          {{ error.$message }}
+        </div>
+        <button @click="onToggle">
+          Toggle All Ouput
+        </button>
+        <pre v-show="showAll">{{ v1$ }}</pre>
+      </div>
+
+      <div>
+        <div>v2$ control</div>
+        <div :class="{ valid: !v2$.$error && v2$.$dirty, error: v2$.$error }">
+          <input
+            v-model="v2$.secondNumber.$model"
+            type="text"
+          >
+        </div>
+        <div
+          v-for="(error, index) in v2$.secondNumber.$errors"
+          :key="index"
+        >
+          {{ error.$message }}
+        </div>
+        <button @click="onToggle">
+          Toggle All Ouput
+        </button>
+        <pre v-show="showAll">{{ v2$ }}</pre>
+      </div>
+      <child-component v-if="showChild" />
+    </div>
+    <button @click.prevent="showChild = !showChild">
+      Toggle child on/off
+    </button>
+  </div>
+</template>
+
+<script>
+import { reactive, ref } from 'vue'
+import useVuelidate from '@vuelidate/core'
+import { required } from '@vuelidate/validators'
+import ChildComponent from './ChildWithScope.vue'
+
+export default {
+  name: 'App',
+  components: {
+    ChildComponent
+  },
+  setup () {
+    const showAll = ref(false)
+    const showChild = ref(false)
+    const rules1 = {
+      number: {
+        required
+      }
+    }
+    const state1 = reactive({
+      number: 1
+    })
+
+    const rules2 = {
+      secondNumber: {
+        required
+      }
+    }
+    const state2 = reactive({
+      secondNumber: 1
+    })
+
+    const v1$ = useVuelidate(rules1, state1, { $registerAs: 'v1' })
+    const v2$ = useVuelidate(rules2, state2, { $registerAs: 'v2' })
+
+    async function onToggle () {
+      showAll.value = !showAll.value
+      const valid1 = await v1$.value.$validate()
+      const valid2 = await v2$.value.$validate()
+      console.warn(`v1$: ${valid1}`, `v2$: ${valid2}`)
+      console.warn(v1$.value, v2$.value)
+    }
+
+    return { v1$, v2$, showAll, showChild, onToggle }
+  }
+}
+</script>
+
+<style scoped>
+.row {
+  display: flex;
+  flex-flow: row wrap;
+}
+
+.valid input {
+  border: 1px solid green;
+}
+
+.error input {
+  border: 1px solid red;
+}
+</style>

--- a/packages/test-project/src/routes.js
+++ b/packages/test-project/src/routes.js
@@ -6,6 +6,7 @@ import CollectionValidations from './components/CollectionValidations.vue'
 import I18nSimpleForm from './components/I18nSimpleForm.vue'
 import ExternalValidationsForm from './components/ExternalValidationsForm.vue'
 import AsyncValidators from './components/AsyncValidators.vue'
+import NestedValidationsWithScopes from './components/NestedValidationsWithScopes/ParentValidator.vue'
 
 export const routes = [
   {
@@ -39,5 +40,9 @@ export const routes = [
   {
     path: '/external-validations',
     component: ExternalValidationsForm
+  },
+  {
+    path: '/nested-validations-with-scopes',
+    component: NestedValidationsWithScopes
   }
 ]


### PR DESCRIPTION
## Summary

This PR fixes a bug where multiple Vuelidate instances from the same component did not collect the children instances. Fixes #960 

## Testing

1. run `yarn install` on the root of the package
2. Go to the `test-project` package
3. run `yarn run dev`
4. Go to http://localhost:3000/nested-validations-with-scopes
5. Toggle the child on/off and toggle the output.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
