### PR TITLE
Fix incorrect vuelidate instance naming (v$ vs $v)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The easiest way to display errors is to use the form's top level `$errors` prope
 ```vue
 
 <p
-  v-for="(error, index) of $v.$errors"
+  v-for="(error, index) of v$.$errors"
   :key="index"
 >
 <strong>{{ error.$validator }}</strong>
@@ -204,7 +204,7 @@ You can also check for errors on each form property:
 
 ```vue
 <p
-  v-for="(error, index) of $v.name.$errors"
+  v-for="(error, index) of v$.name.$errors"
   :key="index"
 >
 <!-- Same as above -->


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
