### PR TITLE
fix typing for createI18nMessage (fix #972)

### DIFF
--- a/packages/validators/index.d.ts
+++ b/packages/validators/index.d.ts
@@ -89,12 +89,10 @@ export function createI18nMessage({ t, messagePath, messageParams }: {
   t: typeof TranslationFunction;
   messagePath?: typeof messagePathFactory;
   messageParams?: typeof messageParamsFactory;
-}): (
-  validator: ValidationRule | ValidatorWrapper,
+}): <T extends (ValidationRule | ValidatorWrapper)>(
+  validator: T,
   options?: {
     withArguments?: boolean,
     messagePath?: typeof messagePathFactory,
     messageParams?: typeof messageParamsFactory,
-  }) =>
-  ValidationRuleWithParams |
-  ((...args: unknown[]) => ValidationRuleWithParams)
+  }) => T

--- a/packages/validators/index.d.ts
+++ b/packages/validators/index.d.ts
@@ -83,29 +83,19 @@ export interface MessageProps {
   $propertyPath: string,
 }
 
-export type ValidatorWrapper = 
-  typeof and | 
-  typeof between | 
-  typeof macAddress | 
-  typeof maxLength | 
-  typeof maxValue | 
-  typeof minValue | 
-  typeof minLength | 
-  typeof not | 
-  typeof not | 
-  typeof or | 
-  typeof requiredIf | 
-  typeof requiredUnless | 
-  typeof sameAs;
+export type ValidatorWrapper = (...args: any[]) => ValidationRule ;
 
-export function createI18nMessage({ t, messagePath, messageParams }: {
-  t: typeof TranslationFunction;
-  messagePath?: typeof messagePathFactory;
-  messageParams?: typeof messageParamsFactory;
-}): <T extends (ValidationRule | ValidatorWrapper)>(
+declare function withI18nMessage <T extends (ValidationRule | ValidatorWrapper)>(
   validator: T,
   options?: {
     withArguments?: boolean,
     messagePath?: typeof messagePathFactory,
     messageParams?: typeof messageParamsFactory,
-  }) => T
+  }): T
+
+export function createI18nMessage({ t, messagePath, messageParams }: {
+  t: typeof TranslationFunction;
+  messagePath?: typeof messagePathFactory;
+  messageParams?: typeof messageParamsFactory;
+}): typeof withI18nMessage
+

--- a/packages/validators/index.d.ts
+++ b/packages/validators/index.d.ts
@@ -83,7 +83,20 @@ export interface MessageProps {
   $propertyPath: string,
 }
 
-export type ValidatorWrapper = (...args: unknown[]) => ValidationRuleWithParams
+export type ValidatorWrapper = 
+  typeof and | 
+  typeof between | 
+  typeof macAddress | 
+  typeof maxLength | 
+  typeof maxValue | 
+  typeof minValue | 
+  typeof minLength | 
+  typeof not | 
+  typeof not | 
+  typeof or | 
+  typeof requiredIf | 
+  typeof requiredUnless | 
+  typeof sameAs;
 
 export function createI18nMessage({ t, messagePath, messageParams }: {
   t: typeof TranslationFunction;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: typing

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I didn't know how to test the changes other than to create a file, composing all validators with the createI18nMessage function and checking that no typescript error is thrown. The function `notValidator` was added as a reference and should throw an error of course. 


![Screenshot 2021-12-07 at 09 13 09](https://user-images.githubusercontent.com/26228448/144991541-7e040ef3-51ed-422e-8347-bf90d2657244.png)


