### PR TITLE
feat: allow passing external vue instance, closes #815

### DIFF
--- a/packages/docs/src/advanced_usage.md
+++ b/packages/docs/src/advanced_usage.md
@@ -763,3 +763,21 @@ const required = withI18nMessage(validators.required)
 ```js
 const required = withI18nMessage(validators.required, { messagePath: () => 'overrides.required' })
 ```
+
+
+## Calling useVuelidate from async setup function
+
+In situations where you need to call useVuelidate from outside your setup function, or in an async setup function, you should use the `currentVueInstance` config to pass
+the component's vue instance.
+
+```js
+export default {
+  render: () => {},
+  async setup() {
+    const currentVueInstance = getCurrentInstance()
+    const result = await doAsyncStuff()
+    const vuelidate = useVuelidate(rules, result.state, { currentVueInstance })
+    return { vuelidate }
+  }
+}
+```

--- a/packages/docs/src/examples.md
+++ b/packages/docs/src/examples.md
@@ -52,7 +52,7 @@ export default {
   },
   methods: {
     async submit () {
-      const result = await this.v$.validate()
+      const result = await this.v$.$validate()
       if (!result) {
         // notify user form is invalid
         return

--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -1,4 +1,5 @@
-import { Ref, UnwrapRef, defineComponent } from 'vue-demi';
+import { ComponentInternalInstance } from '@vue/runtime-core'
+import { Ref, UnwrapRef, defineComponent, getCurrentInstance } from 'vue-demi';
 type Component = ReturnType<typeof defineComponent>;
 
 /*
@@ -172,7 +173,8 @@ export interface GlobalConfig {
   $autoDirty?: boolean
   $lazy?: boolean,
   $externalResults?: ServerErrors | Ref<ServerErrors> | UnwrapRef<ServerErrors>,
-  $rewardEarly?: boolean
+  $rewardEarly?: boolean,
+  currentVueInstance?: ComponentInternalInstance | null
 }
 
 export function useVuelidate(globalConfig?: GlobalConfig): Ref<Validation>;

--- a/packages/vuelidate/src/index.js
+++ b/packages/vuelidate/src/index.js
@@ -32,9 +32,9 @@ export function useVuelidate (validations, state, globalConfig = {}) {
     validations = undefined
     state = undefined
   }
-  let { $registerAs, $scope = CollectFlag.COLLECT_ALL, $stopPropagation, $externalResults } = globalConfig
+  let { $registerAs, $scope = CollectFlag.COLLECT_ALL, $stopPropagation, $externalResults, currentVueInstance } = globalConfig
 
-  const instance = getCurrentInstance()
+  const instance = currentVueInstance || getCurrentInstance()
 
   const componentOptions = instance
     ? (isVue3 ? instance.type : instance.proxy.$options)


### PR DESCRIPTION
## Summary

This PR allows passing the instance of the Vue component gotten from `getCurrentInstance`, via the  `currentVueInstance` config.

closes #815

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
