### PR TITLE
export BaseValidation for typing props

### DIFF
--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -91,7 +91,7 @@ export interface ErrorObject {
   readonly $uid: string,
 }
 
-type BaseValidation <
+export type BaseValidation <
   T = unknown,
   Vrules extends ValidationRuleCollection<T> | undefined = undefined,
 > = (


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

**Other information:**

This is useful for typing props where you want a generic way to access a validators properties like so:

```vue
<script lang="ts" setup>
  import type { BaseValidation } from '@vuelidate/core'
  import type { PropType } from 'vue'

  defineProps({
    validator: { type: Object as PropType<BaseValidation<any, any>>, required: true },
  })
</script>

<template>
  <ul v-if="validator.$dirty && validator.$invalid">
    <template v-for="error in validator.$errors">
      <li>
        <span class="text-danger ml-1 mt-2 block">{{ error.$message }}</span>
      </li>
    </template>
  </ul>
</template>
```
  
```vue 
<ErrorDisplay :validator="$v.prop">
```