### PR TITLE
fix: add iife exports to all packages, closes #1001

### DIFF
--- a/packages/components/bili.config.js
+++ b/packages/components/bili.config.js
@@ -2,8 +2,11 @@
 module.exports = {
   input: './index.js',
   output: {
-    format: ['es', 'cjs'],
+    format: ['es', 'cjs', 'iife'],
     moduleName: 'VuelidateComponents'
   },
-  externals: [/packages\/(vuelidate|validators)/]
+  externals: [/packages\/(vuelidate|validators)/],
+  globals: {
+    '@vuelidate/core': 'Vuelidate'
+  }
 }

--- a/packages/components/bili.config.js
+++ b/packages/components/bili.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   input: './index.js',
   output: {
-    format: ['es', 'cjs', 'iife'],
+    format: ['es', 'cjs', 'iife-min'],
     moduleName: 'VuelidateComponents'
   },
   externals: [/packages\/(vuelidate|validators)/],

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -10,6 +10,11 @@
   },
   "module": "dist/index.esm.js",
   "main": "dist/index.js",
+  "unpkg": "dist/index.iife.min.js",
+  "jsdelivr": "dist/index.iife.min.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "bili"
   },

--- a/packages/docs/src/index.md
+++ b/packages/docs/src/index.md
@@ -22,6 +22,26 @@ npm install @vuelidate/core @vuelidate/validators
 yarn add @vuelidate/core @vuelidate/validators
 ```
 
+## Using CDN
+
+Vuelidate also exposes a browser ready version, that you can use directly without a bundler.
+Add these imports to your browser:
+
+```html
+<!-- Vue-->
+<!--  For Vue 2 -->
+<!--  <script src="https://cdn.jsdelivr.net/npm/vue@2"></script>-->
+<!--  <script src="https://cdn.jsdelivr.net/npm/@vue/composition-api"></script>-->
+<!--  For Vue 3 -->
+<script src="https://cdn.jsdelivr.net/npm/vue@3"></script>
+<!--  Vuelidate -->
+<script src="https://cdn.jsdelivr.net/npm/vue-demi"></script>
+<script src="https://cdn.jsdelivr.net/npm/@vuelidate/core"></script>
+<script src="https://cdn.jsdelivr.net/npm/@vuelidate/validators"></script>
+```
+
+Now you can access use `VueDemi`, `Vuelidate` and `VuelidateValidators` to build validations.
+
 ## Getting Started
 
 ::: tip

--- a/packages/test-project/index-iife.html
+++ b/packages/test-project/index-iife.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+  <!--  START -->
+  <!--  For Vue 2 -->
+  <!--  <script src="https://cdn.jsdelivr.net/npm/vue@2"></script>-->
+  <!--  <script src="https://cdn.jsdelivr.net/npm/@vue/composition-api"></script>-->
+  <!--  For Vue 3 -->
+  <script src="https://cdn.jsdelivr.net/npm/vue@3"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue-demi"></script>
+  <!--  END -->
+  <script src="../vuelidate/dist/index.iife.min.js"></script>
+  <script src="../validators/dist/index.iife.min.js"></script>
+</head>
+<body>
+<div id="app">
+  <div class="SimpleForm">
+    <label>name</label>
+    <input
+      v-model="name"
+      :class="{ error: v$.name.$error }"
+      type="text"
+    >
+    <button @click="validate">
+      Validate
+    </button>
+    <button @click="v$.$touch">
+      $touch
+    </button>
+    <button @click="v$.$reset">
+      $reset
+    </button>
+    <button @click="v$.name.$commit">
+      $commit
+    </button>
+    <div
+      v-if="v$.$errors.length"
+      style="background: rgba(234,163,163,0.62); color: #861e1e; padding: 10px 15px"
+    >
+      <p
+        v-for="(error, index) of v$.$errors"
+        :key="index"
+        style="padding: 0; margin: 5px 0"
+      >
+        {{ error.$message }}
+      </p>
+    </div>
+    <pre>{{ v$ }}</pre>
+  </div>
+</div>
+
+<script>
+const { required, minLength, helpers } = VuelidateValidators
+VueDemi.createApp({
+  setup () {
+    const name = VueDemi.ref('')
+
+    const v$ = Vuelidate.useVuelidate(
+      {
+        name: {
+          required: helpers.withMessage('This field is required', required),
+          minLength: minLength(4),
+          is12345: {
+            $validator: v => v === '12345',
+            $message: 'Is not 12345'
+          }
+        }
+      },
+      { name },
+      { $autoDirty: true }
+    )
+    return { name, v$ }
+  },
+  methods: {
+    validate () {
+      this.v$.$validate({ silent: true }).then((result) => {
+        console.log('Result is', result)
+      })
+    }
+  }
+}).mount('#app')
+</script>
+</body>
+</html>

--- a/packages/validators/bili.config.js
+++ b/packages/validators/bili.config.js
@@ -1,9 +1,9 @@
 /** @type {import('bili').Config} */
 module.exports = {
-  input: 'src/index.js',
+  input: ['src', 'src/raw'],
   output: {
     format: ['esm', 'cjs', 'iife-min'],
-    moduleName: 'Vuelidate'
+    moduleName: 'VuelidateValidators'
   },
   globals: {
     'vue-demi': 'VueDemi'

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -5,6 +5,8 @@
   "main": "dist/index.js",
   "types": "index.d.ts",
   "module": "dist/index.esm.js",
+  "unpkg": "dist/index.iife.min.js",
+  "jsdelivr": "dist/index.iife.min.js",
   "repository": {
     "url": "https://github.com/vuelidate/vuelidate",
     "type": "git",
@@ -12,7 +14,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "bili src src/raw --format esm --format cjs",
+    "build": "bili",
     "dev": "yarn build --watch",
     "test:unit": "jest",
     "lint": "eslint src"

--- a/packages/vuelidate/package.json
+++ b/packages/vuelidate/package.json
@@ -5,6 +5,8 @@
   "main": "dist/index.js",
   "types": "index.d.ts",
   "module": "dist/index.esm.js",
+  "unpkg": "dist/index.iife.min.js",
+  "jsdelivr": "dist/index.iife.min.js",
   "repository": {
     "url": "https://github.com/vuelidate/vuelidate",
     "type": "git",


### PR DESCRIPTION
## Summary

This PR adds IIFE support to the packages. closes #1001 

This should allow using through CDN.

Users need to make sure they have the libraries below in order, for Vuelidate to work in the browser directly

1. Vue, 
2. VueCompositionAPI 
3. VueDemi 