### PR TITLE
fix(core): correct type definition of ValidationArgs

### DIFF
--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -58,7 +58,7 @@ export type ValidationRule <T = any> = ValidationRuleWithParams<any, T> | Valida
 export type ValidationRuleCollection <T = any> = Record<string, ValidationRule<T>>;
 
 export type ValidationArgs<T = unknown> = {
-  [key in keyof T]: ValidationArgs<T[key]> | ValidationRuleCollection<typeof T[key]> | ValidationRule<typeof T[key]>
+  [key in keyof T]: ValidationArgs<T[key]> | ValidationRuleCollection<T[key]> | ValidationRule<T[key]>
 }
 
 export interface RuleResultWithoutParams {


### PR DESCRIPTION
remove incorrect use of 'typeof' operator that caused a syntax error (ts(2693))

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
tsc complained about the type definitions introduced in 073f3d8 even though compilation with bili worked and all unit tests ran successfully. 