### PR TITLE
add MessageProps $params types to attributes (feat #1030)

### DIFF
--- a/packages/validators/index.d.ts
+++ b/packages/validators/index.d.ts
@@ -75,17 +75,17 @@ export function messageParamsFactory(params: {
 export interface MessageProps {
   $model: string;
   $property: string;
-  $params: object;
+  $params: { [attr: string] : any };
   $validator: string;
-  $pending: boolean,
-  $invalid: boolean,
-  $response: unknown,
-  $propertyPath: string,
+  $pending: boolean;
+  $invalid: boolean;
+  $response: unknown;
+  $propertyPath: string;
 }
 
 export type ValidatorWrapper = (...args: any[]) => ValidationRule ;
 
-declare function withI18nMessage <T extends (ValidationRule | ValidatorWrapper)>(
+declare function withI18nMessage <T extends (ValidationRule | ValidatorWrapper)>(
   validator: T,
   options?: {
     withArguments?: boolean,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

It's just adding types to $params in Interface MessageProps, because of TypeScript errors in WebStorm.