### PR TITLE
refactor: iterate the rules in the forEach state, not the state, closes #1002

### DIFF
--- a/packages/validators/src/utils/__tests__/forEach.spec.js
+++ b/packages/validators/src/utils/__tests__/forEach.spec.js
@@ -47,8 +47,7 @@ describe('forEach', () => {
             required: false,
             $invalid: true,
             $error: true
-          },
-          surname: {}
+          }
         }
       ],
       $errors: [
@@ -72,8 +71,7 @@ describe('forEach', () => {
               $response: false,
               $validator: 'required'
             }
-          ],
-          surname: []
+          ]
         }
       ],
       $valid: false

--- a/packages/validators/src/utils/forEach.js
+++ b/packages/validators/src/utils/forEach.js
@@ -6,9 +6,9 @@ export default function forEach (validators) {
       // go over the collection. It can be a ref as well.
       return unwrap(collection).reduce((previous, collectionItem) => {
         // go over each property
-        const collectionEntryResult = Object.entries(collectionItem).reduce((all, [property, $model]) => {
-          // get the validators for this property
-          const innerValidators = validators[property] || {}
+        const collectionEntryResult = Object.entries(validators).reduce((all, [property, innerValidators]) => {
+          // get the model value for this property
+          const $model = collectionItem[property] || ''
           // go over each validator and run it
           const propertyResult = Object.entries(innerValidators).reduce((all, [validatorName, currentValidator]) => {
             // extract the validator. Supports simple and extended validators.


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The PR changes how the `forEach` helper builds it's state. Instead of iterating over the properties in a collection item, it iterates over the rules instead. This way if your state is missing a property, but the validator is there, it will not throw an error. closes #1002 