### PR TITLE
feat: add index to forEach and ValidateEach helpers, closes #1059

### DIFF
--- a/packages/components/src/ValidateEach.js
+++ b/packages/components/src/ValidateEach.js
@@ -14,6 +14,10 @@ export default {
     options: {
       type: Object,
       default: () => ({})
+    },
+    index: {
+      type: Number,
+      default: 0
     }
   },
   setup (props, { slots }) {

--- a/packages/validators/src/utils/__tests__/forEach.spec.js
+++ b/packages/validators/src/utils/__tests__/forEach.spec.js
@@ -26,13 +26,15 @@ describe('forEach', () => {
   })
 
   it('runs the validator against each property', () => {
-    forEach(rules).$validator(state)
+    const siblingState = { siblings: {} }
+    const vm = { foo: 'bar' }
+    forEach(rules).$validator(state, siblingState, vm)
     expect(isFoo).toHaveBeenCalledTimes(2)
     expect(required).toHaveBeenCalledTimes(2)
-    expect(isFoo).toHaveBeenCalledWith('', state[0])
-    expect(isFoo).toHaveBeenCalledWith('Foo', state[1])
-    expect(required).toHaveBeenCalledWith('', state[0])
-    expect(required).toHaveBeenCalledWith('Foo', state[1])
+    expect(isFoo).toHaveBeenCalledWith('', state[0], 0, siblingState, vm)
+    expect(isFoo).toHaveBeenCalledWith('Foo', state[1], 1, siblingState, vm)
+    expect(required).toHaveBeenCalledWith('', state[0], 0, siblingState, vm)
+    expect(required).toHaveBeenCalledWith('Foo', state[1], 1, siblingState, vm)
   })
 
   it('does not throw, if a property does not have a validator', () => {
@@ -93,8 +95,8 @@ describe('forEach', () => {
 
   it('passes all extra params to the validators', () => {
     forEach(rules).$validator(state, 'foo', 'bar', 'baz')
-    expect(isFoo).toHaveBeenCalledWith(state[0].name, state[0], 'foo', 'bar', 'baz')
-    expect(isFoo).toHaveBeenCalledWith(state[1].name, state[1], 'foo', 'bar', 'baz')
+    expect(isFoo).toHaveBeenCalledWith(state[0].name, state[0], 0, 'foo', 'bar', 'baz')
+    expect(isFoo).toHaveBeenCalledWith(state[1].name, state[1], 1, 'foo', 'bar', 'baz')
   })
 
   it('returns the a validation result object, with $data, $errors and $valid', () => {

--- a/packages/validators/src/utils/forEach.js
+++ b/packages/validators/src/utils/forEach.js
@@ -4,7 +4,7 @@ export default function forEach (validators) {
   return {
     $validator (collection, ...others) {
       // go over the collection. It can be a ref as well.
-      return unwrap(collection).reduce((previous, collectionItem) => {
+      return unwrap(collection).reduce((previous, collectionItem, index) => {
         // go over each property
         const collectionEntryResult = Object.entries(collectionItem).reduce((all, [property, $model]) => {
           // get the validators for this property
@@ -14,7 +14,7 @@ export default function forEach (validators) {
             // extract the validator. Supports simple and extended validators.
             const validatorFunction = unwrapNormalizedValidator(currentValidator)
             // Call the validator, passing the VM as this, the value, current iterated object and the rest.
-            const $response = validatorFunction.call(this, $model, collectionItem, ...others)
+            const $response = validatorFunction.call(this, $model, collectionItem, index, ...others)
             // extract the valid from the result
             const $valid = unwrapValidatorResponse($response)
             // store the entire response for later


### PR DESCRIPTION
## Summary

This PR adds an `index` prop to the ValidateEach component, as well as the `forEach` helper. This is technically a breaking change, as it shifts the params passed to the validators, but I think this is a good addition to have.

```
const eachItemValidator(modelValue, siblings, index, collectionSiblings, VM) {}
```

closes #1059

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
