### PR TITLE
feat: add validation groups

### DIFF
--- a/packages/docs/src/advanced_usage.md
+++ b/packages/docs/src/advanced_usage.md
@@ -786,3 +786,39 @@ export default {
   }
 }
 ```
+
+## Validation Groups
+
+You may want to group a few validation rules under one roof, in which case a validation group is a perfect choice.
+
+To create a validation group, you must specify a config property at the top level of your rules, called `$validationGroups`.
+
+This is an object that holds the name of your groups and an array of property paths, which will be the group itself.
+
+```js
+const rules = {
+  number: { isEven },
+  nested: {
+    word: { required: v => !!v }
+  },
+  $validationGroups: {
+    firstGroup: ['number', 'nested.word']
+  }
+}
+```
+
+In the above example, it will create a group called `firstGroup` that will reflect the state of `number` and `nested.word`.
+
+You can see all your defined groups in the `v$.$validationGroups` property of your vue instance.
+
+The group has the typical properties of other validations:
+
+```ts
+interface ValidationGroupItem {
+  $invalid: boolean,
+  $error: boolean,
+  $pending: boolean,
+  $errors: ErrorObject[],
+  $silentErrors: ErrorObject[]
+}
+```

--- a/packages/docs/src/migration_guide.md
+++ b/packages/docs/src/migration_guide.md
@@ -193,3 +193,18 @@ export default {
   }
 }
 ```
+
+## Removal of validation groups
+
+Validation groups have been removed, as those would not work with the new composition ways.
+
+### Migration strategy
+
+You can create a computed property that recomputes for the properties you are interested in
+
+```js
+const v$ = useVuelidate(rules, state)
+const groupInvalid = computed(() => {
+  return v$.value.firstProperty.$invalid || v$.value.secondProperty.$invalid
+})
+```

--- a/packages/docs/src/migration_guide.md
+++ b/packages/docs/src/migration_guide.md
@@ -194,17 +194,28 @@ export default {
 }
 ```
 
-## Removal of validation groups
+## Validation groups change
 
-Validation groups have been removed, as those would not work with the new composition ways.
+Validation groups have been moved to the `$validationGroups` config.
 
 ### Migration strategy
 
-You can create a computed property that recomputes for the properties you are interested in
+To create a validation group, you must specify a config property at the top level of your rules, called `$validationGroups`
+
+This is an object that holds validation groups, scoped under a name of your choice:
 
 ```js
-const v$ = useVuelidate(rules, state)
-const groupInvalid = computed(() => {
-  return v$.value.firstProperty.$invalid || v$.value.secondProperty.$invalid
-})
+const rules = {
+  number: { isEven },
+  nested: {
+    word: { required: v => !!v }
+  },
+  $validationGroups: {
+    firstName: ['number', 'nested.word']
+  }
+}
 ```
+
+In the above example, it will create a group called `firstName` that will reflect the state of `number` and `nested.word`.
+
+You can see all your defined groups in the `v$.$validationGroups` property of your vue instance.

--- a/packages/vuelidate/src/utils/index.js
+++ b/packages/vuelidate/src/utils/index.js
@@ -35,3 +35,36 @@ export function paramToRef (param) {
 export function isProxy (value) {
   return isReactive(value) || isReadonly(value)
 }
+
+export function get (obj, stringPath, def) {
+  // Cache the current object
+  let current = obj
+  const path = stringPath.split('.')
+  // For each item in the path, dig into the object
+  for (let i = 0; i < path.length; i++) {
+    // If the item isn't found, return the default (or null)
+    if (!current[path[i]]) return def
+
+    // Otherwise, update the current  value
+    current = current[path[i]]
+  }
+
+  return current
+}
+
+export function gatherBooleanGroupProperties (group, nestedResults, property) {
+  return computed(() => {
+    return group.some((path) => {
+      return get(nestedResults, path, { [property]: false })[property]
+    })
+  })
+}
+
+export function gatherArrayGroupProperties (group, nestedResults, property) {
+  return computed(() => {
+    return group.reduce((all, path) => {
+      const fetchedProperty = get(nestedResults, path, { [property]: false })[property] || []
+      return all.concat(fetchedProperty)
+    }, [])
+  })
+}

--- a/packages/vuelidate/src/utils/sortValidations.js
+++ b/packages/vuelidate/src/utils/sortValidations.js
@@ -12,6 +12,7 @@ export function sortValidations (validationsRaw = {}) {
   const rules = {}
   const nestedValidators = {}
   const config = {}
+  let validationGroups = null
 
   validationKeys.forEach(key => {
     const v = validations[key]
@@ -26,6 +27,9 @@ export function sortValidations (validationsRaw = {}) {
       case isFunction(v):
         rules[key] = { $validator: v }
         break
+      case key === '$validationGroups':
+        validationGroups = v
+        break
       // Catch $-prefixed properties as config
       case key.startsWith('$'):
         config[key] = v
@@ -37,5 +41,5 @@ export function sortValidations (validationsRaw = {}) {
     }
   })
 
-  return { rules, nestedValidators, config }
+  return { rules, nestedValidators, config, validationGroups }
 }

--- a/packages/vuelidate/test/unit/utils.js
+++ b/packages/vuelidate/test/unit/utils.js
@@ -65,10 +65,8 @@ export const shouldBeValidValidationObj = (v) => {
   expect(v).toHaveProperty('$pending', false)
 }
 
-export const shouldBeInvalidValidationObject = ({ v, property, propertyPath = property, validatorName }) => {
-  expect(v).toHaveProperty('$error', false)
-  expect(v).toHaveProperty('$errors', [])
-  expect(v).toHaveProperty('$silentErrors', [{
+export function buildErrorObject (property, propertyPath, validatorName) {
+  return {
     $message: '',
     $params: {},
     $pending: false,
@@ -77,7 +75,13 @@ export const shouldBeInvalidValidationObject = ({ v, property, propertyPath = pr
     $validator: validatorName,
     $response: false,
     $uid: `${propertyPath}-${validatorName}`
-  }])
+  }
+}
+
+export const shouldBeInvalidValidationObject = ({ v, property, propertyPath = property, validatorName }) => {
+  expect(v).toHaveProperty('$error', false)
+  expect(v).toHaveProperty('$errors', [])
+  expect(v).toHaveProperty('$silentErrors', [buildErrorObject(property, propertyPath, validatorName)])
   expect(v).toHaveProperty('$invalid', true)
   expect(v).toHaveProperty('$pending', false)
   expect(v).toHaveProperty('$dirty', false)
@@ -88,26 +92,8 @@ export const shouldBeInvalidValidationObject = ({ v, property, propertyPath = pr
 
 export const shouldBeErroredValidationObject = ({ v, property, propertyPath = property, validatorName }) => {
   expect(v).toHaveProperty('$error', true)
-  expect(v).toHaveProperty('$errors', [{
-    $message: '',
-    $params: {},
-    $pending: false,
-    $property: property,
-    $propertyPath: propertyPath,
-    $validator: validatorName,
-    $response: false,
-    $uid: `${propertyPath}-${validatorName}`
-  }])
-  expect(v).toHaveProperty('$silentErrors', [{
-    $message: '',
-    $params: {},
-    $pending: false,
-    $property: property,
-    $propertyPath: propertyPath,
-    $validator: validatorName,
-    $response: false,
-    $uid: `${propertyPath}-${validatorName}`
-  }])
+  expect(v).toHaveProperty('$errors', [buildErrorObject(property, propertyPath, validatorName)])
+  expect(v).toHaveProperty('$silentErrors', [buildErrorObject(property, propertyPath, validatorName)])
   expect(v).toHaveProperty('$invalid', true)
   expect(v).toHaveProperty('$pending', false)
   expect(v).toHaveProperty('$dirty', true)


### PR DESCRIPTION
## Summary

Adds back validation groups as a top-level config for the rules.

fixes #1051 

## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] It's submitted to the `next` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
