### PR TITLE
docs: Fixed macAddress Example 

### DIFF
--- a/docs-v1/partials/validators/_validators.pug
+++ b/docs-v1/partials/validators/_validators.pug
@@ -89,9 +89,9 @@ mixin validatorRow(validator, params)
             +validatorRow('ipAddress')
               | Accepts valid IPv4 addresses in dotted decimal notation like <em>127.0.0.1</em>.
             +validatorRow('macAddress', [ 'separator\=\':\'' ])
-              | Accepts valid MAC addresses like <em>00:ff:11:22:33:44:55</em>. Don't forget to call it <kbd>macAddress()</kbd>, as it has optional parameter.
+              | Accepts valid MAC addresses like <em>00:ff:11:22:33:44</em>. Don't forget to call it <kbd>macAddress()</kbd>, as it has optional parameter.
               | You can specify your own separator instead of <kbd>':'</kbd>.
-              | Provide empty separator <kbd>macAddress('')</kbd> to validate MAC addresses like <em>00ff1122334455</em>.
+              | Provide empty separator <kbd>macAddress('')</kbd> to validate MAC addresses like <em>00ff11223344</em>.
             +validatorRow('sameAs', ['locator *'])
               | Checks for equality with a given property.
             +validatorRow('url')


### PR DESCRIPTION
Given `macAddress` examples are invalid

## Summary

Mac address example on document page are invalid with current `macAddress` validator.

## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] It's submitted to the `next` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included
