### PR TITLE
fix: add ESM loading support

### DIFF
--- a/packages/vuelidate/package.json
+++ b/packages/vuelidate/package.json
@@ -17,6 +17,13 @@
     "dist",
     "index.d.ts"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js"
+    },
+    "./*": "./*"
+  },
   "scripts": {
     "build": "bili",
     "test:unit": "jest",


### PR DESCRIPTION
## Summary

Currently there is an issue when using this package with `vitest` and Vue 2 with the composition api.

Vitest will load the esm version of all the other modules, including `@vue/composition-api`. Then when it hits the vuelidate import it will load the CommonJS version of the package instead of the esm version. Then, when vuelidate CJS `require`s `@vue/composition-api` it will _require_ the module, resulting in _two_ versions of the composition API being loaded.

This results in the "[dual package hazard](https://nodejs.org/api/packages.html#dual-package-hazard)", and `composition-api` starts to throw errors that it was not installed (because the install version is the esm module, not the newly loaded commonjs module). 

You can see that in this callstack when running vitest, vuelidate uses commonjs modules:
```
Error: [vue-composition-api] must call Vue.use(VueCompositionAPI) before using any function.
 ❯ assert node_modules/@vue/composition-api/dist/vue-composition-api.common.js:379:15
 ❯ getVueConstructor node_modules/@vue/composition-api/dist/vue-composition-api.common.js:233:9
 ❯ isComponentInstance node_modules/@vue/composition-api/dist/vue-composition-api.common.js:471:15
 ❯ setupAccessControl node_modules/@vue/composition-api/dist/vue-composition-api.common.js:760:9
 ❯ reactive node_modules/@vue/composition-api/dist/vue-composition-api.common.js:968:5
 ❯ Object.ref node_modules/@vue/composition-api/dist/vue-composition-api.common.js:638:17
 ❯ Proxy.useVuelidate node_modules/@vuelidate/core/dist/index.js:1022:37
    1020|   }
    1021| 
    1022|   const validationResults = vueDemi.ref({});
       |                                     ^
    1023|   const resultsCache = new ResultsStorage();
    1024|   const {
 ❯ setup src/modules/users/role-form.vue:169:50
 ❯ mergedSetupFn node_modules/@vue/composition-api/dist/vue-composition-api.mjs:2165:113
 ❯ mergedSetupFn node_modules/@vue/composition-api/dist/vue-composition-api.mjs:2165:51
```

This PR adds the `exports` option and points to the correct dist file for import usage. I'm not sure if the `*` entry is required, but it [exists in the composition api package](https://github.com/vuejs/composition-api/blob/main/package.json#L24).

I've tested this change in my node_modules folder and its the only thing required for the tests to pass.

## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] It's submitted to the `next` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
