### PR TITLE
fix  #1079 - Add support for Vue 2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "standard-version": "^9.3.1",
     "vue": "^3.2.2",
     "vue-template-compiler": "^2.6.14",
-    "vue2": "npm:vue@2.6.14"
+    "vue2": "npm:vue@2.6.14",
+    "vue2.7": "npm:vue@2.7.5"
   },
   "scripts": {
     "lerna:publish": "lerna publish --conventional-commits",
@@ -60,9 +61,11 @@
     "release:dry": "yarn lerna:build && yarn lerna:version --no-push --no-git-tag-version",
     "test:unit": "npm run test:3",
     "test:2": "npm run use-vue:2 && jest",
+    "test:2.7": "npm run use-vue:2.7 && jest",
     "test:3": "npm run use-vue:3 && jest",
-    "test:all": "npm run test:2 && npm run test:3",
+    "test:all": "npm run test:2 && npm run test:2.7 && npm run test:3",
     "use-vue:2": "node scripts/swap-vue.js 2 && vue-demi-switch 2",
+    "use-vue:2.7": "node scripts/swap-vue.js 2.7 && vue-demi-switch 2.7",
     "use-vue:3": "node scripts/swap-vue.js 3 && vue-demi-switch 3"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/vuelidate/vuelidate.git"
   },
   "dependencies": {
-    "vue-demi": "^0.12.0"
+    "vue-demi": "^0.13.4"
   },
   "optionalDependencies": {
     "@vue/composition-api": "^1.3.1"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "standard-version": "^9.3.1",
     "vue": "^3.2.2",
     "vue-template-compiler": "^2.6.14",
+    "vue-template-compiler2.7": "npm:vue-template-compiler@2.7.5",
     "vue2": "npm:vue@2.6.14",
     "vue2.7": "npm:vue@2.7.5"
   },

--- a/packages/docs/src/advanced_usage.md
+++ b/packages/docs/src/advanced_usage.md
@@ -779,7 +779,7 @@ the `currentVueInstance` config to pass the component's vue instance.
 export default {
   render: () => {},
   async setup () {
-    const currentVueInstance = getCurrentInstance()
+    const currentVueInstance = getCurrentInstance()?.proxy
     const result = await doAsyncStuff()
     const vuelidate = useVuelidate(rules, result.state, { currentVueInstance })
     return { vuelidate }

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
-    "vue-demi": "^0.12.0"
+    "vue-demi": "^0.13.4"
   },
   "devDependencies": {
     "bili": "^5.0.5",

--- a/packages/vuelidate/package.json
+++ b/packages/vuelidate/package.json
@@ -31,7 +31,7 @@
     "dev": "yarn build --watch"
   },
   "dependencies": {
-    "vue-demi": "^0.12.0"
+    "vue-demi": "^0.13.4"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",

--- a/packages/vuelidate/src/index.js
+++ b/packages/vuelidate/src/index.js
@@ -34,10 +34,10 @@ export function useVuelidate (validations, state, globalConfig = {}) {
   }
   let { $registerAs, $scope = CollectFlag.COLLECT_ALL, $stopPropagation, $externalResults, currentVueInstance } = globalConfig
 
-  const instance = currentVueInstance || getCurrentInstance()
+  const instance = currentVueInstance || getCurrentInstance()?.proxy
 
   const componentOptions = instance
-    ? instance.proxy.$options
+    ? instance.$options
     : {}
   // if there is no registration name, add one.
   if (!$registerAs && instance) {
@@ -55,7 +55,7 @@ export function useVuelidate (validations, state, globalConfig = {}) {
     sendValidationResultsToParent,
     removeValidationResultsFromParent
   } = instance
-    ? nestedValidations({ $scope, instance: instance.proxy })
+    ? nestedValidations({ $scope, instance })
     : { childResults: ref({}) }
 
   // Options API
@@ -66,7 +66,7 @@ export function useVuelidate (validations, state, globalConfig = {}) {
     onBeforeMount(() => {
       // Delay binding state to validations defined with the Options API until mounting, when the data
       // has been attached to the component instance. From that point on it will be reactive.
-      state.value = instance.proxy
+      state.value = instance
 
       watch(() => isFunction(rules) ? rules.call(state.value, new ComputedProxyFactory(state.value)) : rules,
         (validations) => {
@@ -76,8 +76,8 @@ export function useVuelidate (validations, state, globalConfig = {}) {
             childResults,
             resultsCache,
             globalConfig,
-            instance: instance.proxy,
-            externalResults: $externalResults || instance.proxy.vuelidateExternalResults
+            instance,
+            externalResults: $externalResults || instance.vuelidateExternalResults
           })
         }, { immediate: true })
     })
@@ -96,7 +96,7 @@ export function useVuelidate (validations, state, globalConfig = {}) {
         childResults,
         resultsCache,
         globalConfig,
-        instance: instance ? instance.proxy : {},
+        instance: instance ?? {},
         externalResults: $externalResults
       })
     }, { immediate: true })

--- a/packages/vuelidate/src/index.js
+++ b/packages/vuelidate/src/index.js
@@ -55,7 +55,7 @@ export function useVuelidate (validations, state, globalConfig = {}) {
     sendValidationResultsToParent,
     removeValidationResultsFromParent
   } = instance
-    ? nestedValidations({ $scope, instance })
+    ? nestedValidations({ $scope, instance: instance.proxy })
     : { childResults: ref({}) }
 
   // Options API

--- a/scripts/swap-vue.js
+++ b/scripts/swap-vue.js
@@ -62,7 +62,6 @@ function resetPackageNames () {
 }
 
 function useTemplateCompilerVersion (version) {
-  console.log('existing!! ? ', !fs.existsSync(vueTemplateCompiler))
   if (!fs.existsSync(vueTemplateCompiler)) {
     console.log('There is no default vue-template-compiler version, finding it')
     if (version === 2.7 && fs.existsSync(vueTemplateCompiler2_7)) {

--- a/scripts/swap-vue.js
+++ b/scripts/swap-vue.js
@@ -1,15 +1,13 @@
+/* eslint-disable camelcase */
 const fs = require('fs')
 const path = require('path')
 
 const Vue2 = path.join(__dirname, '../node_modules/vue2')
-// eslint-disable-next-line camelcase
 const Vue2_7 = path.join(__dirname, '../node_modules/vue2.7')
 const DefaultVue = path.join(__dirname, '../node_modules/vue')
 const Vue3 = path.join(__dirname, '../node_modules/vue3')
 const vueTemplateCompiler = path.join(__dirname, '../node_modules/vue-template-compiler')
-// eslint-disable-next-line camelcase
 const vueTemplateCompiler2_6 = path.join(__dirname, '../node_modules/vue-template-compiler2.6')
-// eslint-disable-next-line camelcase
 const vueTemplateCompiler2_7 = path.join(__dirname, '../node_modules/vue-template-compiler2.7')
 
 const version = Number(process.argv[2]) || 3

--- a/scripts/swap-vue.js
+++ b/scripts/swap-vue.js
@@ -2,6 +2,8 @@ const fs = require('fs')
 const path = require('path')
 
 const Vue2 = path.join(__dirname, '../node_modules/vue2')
+// eslint-disable-next-line camelcase
+const Vue2_7 = path.join(__dirname, '../node_modules/vue2.7')
 const DefaultVue = path.join(__dirname, '../node_modules/vue')
 const Vue3 = path.join(__dirname, '../node_modules/vue3')
 
@@ -15,6 +17,9 @@ function useVueVersion (version) {
     if (version === 2 && fs.existsSync(Vue3)) {
       rename(Vue3, DefaultVue)
       console.log('Renamed "vue3" to "vue"')
+    } else if (version === 2.7 && fs.existsSync(Vue2_7)) {
+      rename(Vue2_7, DefaultVue)
+      console.log('Renamed "vue2.7" to "vue"')
     } else {
       rename(Vue2, DefaultVue)
       console.log('Renamed "vue2" to "vue"')
@@ -22,13 +27,28 @@ function useVueVersion (version) {
   }
 
   if (version === 3 && fs.existsSync(Vue3)) {
-    rename(DefaultVue, Vue2)
+    resetPackageNames()
     rename(Vue3, DefaultVue)
+  } else if (version === 2.7 && fs.existsSync(Vue2_7)) {
+    resetPackageNames()
+    rename(Vue2_7, DefaultVue)
   } else if (version === 2 && fs.existsSync(Vue2)) {
-    rename(DefaultVue, Vue3)
+    resetPackageNames()
     rename(Vue2, DefaultVue)
   } else {
     console.log(`Vue ${version} is already in use`)
+  }
+}
+
+function resetPackageNames () {
+  if (!fs.existsSync(Vue3)) {
+    rename(DefaultVue, Vue3)
+  } else if (!fs.existsSync(Vue2_7)) {
+    rename(DefaultVue, Vue2_7)
+  } else if (!fs.existsSync(Vue2)) {
+    rename(DefaultVue, Vue2)
+  } else {
+    console.error('Unable to reset package names')
   }
 }
 

--- a/scripts/swap-vue.js
+++ b/scripts/swap-vue.js
@@ -83,11 +83,10 @@ function useTemplateCompilerVersion (version) {
 
 function rename (fromPath, toPath) {
   if (!fs.existsSync(fromPath)) return
-  fs.rename(fromPath, toPath, function (err) {
-    if (err) {
-      console.log(err)
-    } else {
-      console.log(`Successfully renamed ${fromPath} to ${toPath} .`)
-    }
-  })
+  try {
+    fs.renameSync(fromPath, toPath)
+    console.log(`Successfully renamed ${fromPath} to ${toPath} .`)
+  } catch (err) {
+    console.log(err)
+  }
 }

--- a/scripts/swap-vue.js
+++ b/scripts/swap-vue.js
@@ -6,6 +6,11 @@ const Vue2 = path.join(__dirname, '../node_modules/vue2')
 const Vue2_7 = path.join(__dirname, '../node_modules/vue2.7')
 const DefaultVue = path.join(__dirname, '../node_modules/vue')
 const Vue3 = path.join(__dirname, '../node_modules/vue3')
+const vueTemplateCompiler = path.join(__dirname, '../node_modules/vue-template-compiler')
+// eslint-disable-next-line camelcase
+const vueTemplateCompiler2_6 = path.join(__dirname, '../node_modules/vue-template-compiler2.6')
+// eslint-disable-next-line camelcase
+const vueTemplateCompiler2_7 = path.join(__dirname, '../node_modules/vue-template-compiler2.7')
 
 const version = Number(process.argv[2]) || 3
 
@@ -19,9 +24,11 @@ function useVueVersion (version) {
       console.log('Renamed "vue3" to "vue"')
     } else if (version === 2.7 && fs.existsSync(Vue2_7)) {
       rename(Vue2_7, DefaultVue)
+      useTemplateCompilerVersion(2.7)
       console.log('Renamed "vue2.7" to "vue"')
     } else {
       rename(Vue2, DefaultVue)
+      useTemplateCompilerVersion(2)
       console.log('Renamed "vue2" to "vue"')
     }
   }
@@ -32,9 +39,11 @@ function useVueVersion (version) {
   } else if (version === 2.7 && fs.existsSync(Vue2_7)) {
     resetPackageNames()
     rename(Vue2_7, DefaultVue)
+    useTemplateCompilerVersion(2.7)
   } else if (version === 2 && fs.existsSync(Vue2)) {
     resetPackageNames()
     rename(Vue2, DefaultVue)
+    useTemplateCompilerVersion(2)
   } else {
     console.log(`Vue ${version} is already in use`)
   }
@@ -52,13 +61,36 @@ function resetPackageNames () {
   }
 }
 
+function useTemplateCompilerVersion (version) {
+  console.log('existing!! ? ', !fs.existsSync(vueTemplateCompiler))
+  if (!fs.existsSync(vueTemplateCompiler)) {
+    console.log('There is no default vue-template-compiler version, finding it')
+    if (version === 2.7 && fs.existsSync(vueTemplateCompiler2_7)) {
+      rename(vueTemplateCompiler2_7, vueTemplateCompiler)
+      console.log('Renamed "vue-template-compliler2.7" to "vue-template-compliler"')
+    } else {
+      rename(vueTemplateCompiler2_6, vueTemplateCompiler)
+      console.log('Renamed "vue-template-compliler2.6" to "vue-template-compliler"')
+    }
+  }
+  if (version === 2.7 && fs.existsSync(vueTemplateCompiler2_7)) {
+    rename(vueTemplateCompiler, vueTemplateCompiler2_6)
+    rename(vueTemplateCompiler2_7, vueTemplateCompiler)
+  } else if (version === 2 && fs.existsSync(vueTemplateCompiler2_6)) {
+    rename(vueTemplateCompiler, vueTemplateCompiler2_7)
+    rename(vueTemplateCompiler2_6, vueTemplateCompiler)
+  } else {
+    console.log(`vue-template-compliler ${version} is already in use`)
+  }
+}
+
 function rename (fromPath, toPath) {
   if (!fs.existsSync(fromPath)) return
   fs.rename(fromPath, toPath, function (err) {
     if (err) {
       console.log(err)
     } else {
-      console.log(`Successfully renamed ${fromPath} to ${toPath}.`)
+      console.log(`Successfully renamed ${fromPath} to ${toPath} .`)
     }
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11052,10 +11052,10 @@ vlq@^0.2.2:
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
   integrity sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==
 
-vue-demi@^0.12.0:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.12.1.tgz#f7e18efbecffd11ab069d1472d7a06e319b4174c"
-  integrity sha512-QL3ny+wX8c6Xm1/EZylbgzdoDolye+VpCXRhI2hug9dJTP3OUJ3lmiKN3CsVV3mOJKwFi0nsstbgob0vG7aoIw==
+vue-demi@^0.13.4:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.13.5.tgz#d5eddbc9eaefb89ce5995269d1fa6b0486312092"
+  integrity sha512-tO3K2bML3AwiHmVHeKCq6HLef2st4zBXIV5aEkoJl6HZ+gJWxWv2O8wLH8qrA3SX3lDoTDHNghLX1xZg83MXvw==
 
 vue-eslint-parser@^7.10.0:
   version "7.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6210,7 +6210,7 @@ has@^1.0.0, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-he@^1.1.0:
+he@^1.1.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -11124,6 +11124,14 @@ vue-router@^4.0.11:
   integrity sha512-CPXvfqe+mZLB1kBWssssTiWg4EQERyqJZes7USiqfW9B5N2x+nHlnsM1D3b5CaJ6qgCvMmYJnz+G0iWjNCvXrg==
   dependencies:
     "@vue/devtools-api" "^6.0.0-beta.18"
+
+"vue-template-compiler2.7@npm:vue-template-compiler@2.7.5":
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.7.5.tgz#f3f1c559bfceb7e953fdc9a5b42602026becec87"
+  integrity sha512-f5aofPdhOtoCW2jnK+iehkfVizDSrLuiyHcgIlGrXlkBXpIDfvm3HNX8emrhEduj5o5NyVulVbwpXW+zpRZQNg==
+  dependencies:
+    de-indent "^1.0.2"
+    he "^1.2.0"
 
 vue-template-compiler@^2.6.14:
   version "2.6.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -474,6 +474,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.8.tgz#61c243a3875f7d0b0962b0543a33ece6ff2f1f17"
   integrity sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw==
 
+"@babel/parser@^7.18.4":
+  version "7.18.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.8.tgz#822146080ac9c62dac0823bb3489622e0bc1cbdf"
+  integrity sha512-RSKRfYX20dyH+elbJK2uqAkVyucL+xXzhqlMD5/ZXx+dAAwpyB7HsvnHe/ZUGOF+xLr5Wx9/JoXVTj6BQE2/oA==
+
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.7.tgz#4eda6d6c2a0aa79c70fa7b6da67763dfe2141050"
@@ -2947,6 +2952,15 @@
     "@vue/compiler-core" "3.2.26"
     "@vue/shared" "3.2.26"
 
+"@vue/compiler-sfc@2.7.5":
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-2.7.5.tgz#57ad9ab41090522cdde3598c0e7a8ecbd911a094"
+  integrity sha512-f2xlkMzBLbTAUy13N4aJBnmb7+86WJqoGqHDibkGHd1/CabpNVvzhpBFlfWJjBrGWIcWywNGgGSuoWzpCUuD4w==
+  dependencies:
+    "@babel/parser" "^7.18.4"
+    postcss "^8.4.14"
+    source-map "^0.6.1"
+
 "@vue/compiler-sfc@3.2.26", "@vue/compiler-sfc@^3.2.2":
   version "3.2.26"
   resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.26.tgz#3ce76677e4aa58311655a3bea9eb1cb804d2273f"
@@ -4606,6 +4620,11 @@ csstype@^2.6.8:
   version "2.6.19"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.19.tgz#feeb5aae89020bb389e1f63669a5ed490e391caa"
   integrity sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==
+
+csstype@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
+  integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
 
 cz-conventional-changelog@3.2.0:
   version "3.2.0"
@@ -8143,6 +8162,11 @@ nanoid@^3.1.30:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.32.tgz#8f96069e6239cc0a9ae8c0d3b41a3b4933a88c0a"
   integrity sha512-F8mf7R3iT9bvThBoW4tGXhXFHCctyCiUUPrWF8WaTqa3h96d9QybkSeba43XVOOE3oiLfkVDe4bT8MeGmkrTxw==
 
+nanoid@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -9225,6 +9249,15 @@ postcss@^8.1.10, postcss@^8.4.5:
     picocolors "^1.0.0"
     source-map-js "^1.0.1"
 
+postcss@^8.4.14:
+  version "8.4.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
+  integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
 preact@^10.0.0:
   version "10.6.4"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.6.4.tgz#ad12c409ff1b4316158486e0a7b8d43636f7ced8"
@@ -10072,6 +10105,11 @@ sort-keys@^4.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.1.tgz#a1741c131e3c77d048252adfa24e23b908670caf"
   integrity sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==
+
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-resolve@^0.5.0:
   version "0.5.3"
@@ -11094,6 +11132,14 @@ vue-template-compiler@^2.6.14:
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
+
+"vue2.7@npm:vue@2.7.5":
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.7.5.tgz#ad65844f73474e2ed02b629363ff1550603b717f"
+  integrity sha512-mUDXXgBIFr9dk0k/3dpB6wtnCxRhe9mbGxWLtha9mTUrEWkdkZW1d58vl98VKWH067NA8f1Wj4Qwq7y7DDYfyw==
+  dependencies:
+    "@vue/compiler-sfc" "2.7.5"
+    csstype "^3.1.0"
 
 "vue2@npm:vue@2.6.14":
   version "2.6.14"


### PR DESCRIPTION
## Summary

Add support for vue 2.7

Allow to unit test for 2.7 with vue-demi

fixes #1079


Even if vue 2.7 doesn't need `vue-template-compiler` itself
it's still needed because of `@vue/test-utils`  and need to match the current vue version, so it is why I added this behavior to `swap-vue.js`


https://blog.vuejs.org/posts/vue-2-7-naruto.html
> Upgrade vue to ^2.7.0. You can also remove vue-template-compiler from the dependencies - it is no longer needed in 2.7.
> 
> Note: if you are using @vue/test-utils, you may need to keep it in the dependencies for now, but this requirement will also be lifted in a new release of test utils.

fixes #1079



## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] It's submitted to the `next` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

