### PR TITLE
fix: extend BaseValidation type to allow accessing form propert…

### DIFF
--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -115,6 +115,9 @@ export type BaseValidation <
   readonly $reset: () => void
   readonly $commit: () => void
   readonly $validate: () => Promise<boolean>
+
+  // For accessing individual form properties on v$
+  readonly [key: string]: any
 };
 
 export type NestedValidations <Vargs extends ValidationArgs = ValidationArgs, T = unknown> = {


### PR DESCRIPTION
## Summary

When running my production build with Vue 3, and TypeScript 4.7.2, I get an error that:

````
TS2339: Property 'values' does not exist on type 'Validation<ValidationArgs<unknown>, unknown>'.
````

The compiler claims that "values" does not exist on v$. I'm trying to access an individual form property `values` directly on the `v$` object, just as described here: https://vuelidate-next.netlify.app/guide.html#displaying-error-messages

Adding the suggested line, fixes the issue for me, and lets me compile, while still referencing my form values directly on v$, such as `v$.values.username.$errors`.

## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No (or so I think, since the change is very fault tolerant)

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [X] It's submitted to the `next` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
