### PR TITLE
fix(core): UID doesn't exist on the component public instance in Vue 3 #1090 

### DIFF
--- a/packages/vuelidate/src/index.js
+++ b/packages/vuelidate/src/index.js
@@ -24,6 +24,9 @@ import { ComputedProxyFactory } from './utils/ComputedProxyFactory'
  * @param {GlobalConfig} [globalConfig] - Config Object
  * @return {ComputedRef<*>}
  */
+
+let uid = 0
+
 export function useVuelidate (validations, state, globalConfig = {}) {
   // if we pass only one argument, its most probably the globalConfig.
   // This use case is so parents can just collect results of child forms.
@@ -40,11 +43,8 @@ export function useVuelidate (validations, state, globalConfig = {}) {
     ? instance.$options
     : {}
   // if there is no registration name, add one.
-  if (!$registerAs && instance) {
-    // NOTE:
-    // ._uid // Vue 2.x Composition-API plugin
-    // .uid // Vue 3.0
-    const uid = instance.uid || instance._uid
+  if (!$registerAs) {
+    uid += 1
     $registerAs = `_vuelidate_${uid}`
   }
   const validationResults = ref({})

--- a/packages/vuelidate/test/unit/specs/validation.spec.js
+++ b/packages/vuelidate/test/unit/specs/validation.spec.js
@@ -621,6 +621,33 @@ describe('useVuelidate', () => {
     })
   })
 
+  it('collects multiple child validation giving them unique id if registerAs is omitted', async () => {
+    const { state, validations } = simpleValidation()
+    const child1 = createSimpleComponent(() => useVuelidate(validations, state))
+    const child2 = createSimpleComponent(() => useVuelidate(validations, state))
+
+    const Component = {
+      setup () {
+        const state = simpleValidation()
+        const v = useVuelidate(state.validations, state.state)
+        return { v }
+      },
+      render () {
+        return h('div', [h(child1), h(child2)])
+      }
+    }
+    const wrapper = mount(Component)
+    const uidRegex = /_vuelidate_.*/
+    const childValidation = []
+    for (const key in wrapper.vm.v) {
+      if (key.match(uidRegex)) {
+        childValidation.push(key)
+      }
+    }
+    expect(childValidation).toHaveLength(2)
+    expect(childValidation[0]).not.toEqual(childValidation[1])
+  })
+
   describe('$error', () => {
     it('returns `true` if both `$invalid` and $dirty` are true, but initially false', async () => {
       const number = ref(2)


### PR DESCRIPTION
## Summary

fixes #1090 

`uid` is not on the `ComponentPublicInstance` but on the `ComponentInternalInstance` on vue3

we can do as before by accessing the internal instance with instance.$.uid
```js
    const uid = instance?.$?.uid || instance._uid
    $registerAs = `_vuelidate_${uid}`
 ```
but accessing internal instance is not recommended, I suggest to create our own uid instead.
The vuelidate uid doesn't need to be same as the vue uid right ?


## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] It's submitted to the `next` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
