### PR TITLE
Added Using mixed state section to Advanced usage documentation

### DIFF
--- a/packages/docs/src/advanced_usage.md
+++ b/packages/docs/src/advanced_usage.md
@@ -95,6 +95,40 @@ export default {
 }
 ```
 
+### Using mixed (e.g. `reactive` and `computed`) state
+
+```js
+import { computed, reactive } from 'vue'
+import { useVuelidate } from '@vuelidate/core'
+import { minValue, required } from '@vuelidate/validators'
+
+export default {
+  setup () {
+    // reactive state, e.g. form data
+    const data = reactive({
+      type: '',
+      name: '',
+      targetMonth: new Date().getMonth(),
+      targetYear: new Date().getFullYear()
+    })
+    // computed state which needs validation
+    const targetDate = computed(() => new Date(data.targetYear, data.targetMonth + 1, 0)) // last day in the month
+
+    const rules = {
+      data: {
+        type: { required },
+        name: { required }
+      },
+      targetDate: { minValue: minValue(new Date()) },
+    }
+
+    const v$ = useVuelidate(rules, { data, targetDate })
+
+    return { data, v$ }
+  }
+}
+```
+
 ## Nested validations
 
 When using `useVuelidate`, Vuelidate will collect all validation `$errors` and `$silentErrors` from all nested components. No need to pass any props


### PR DESCRIPTION
## Summary

Added `Using mixed state section` to `Advanced usage` documentation

fixes #([1105](https://github.com/vuelidate/vuelidate/issues/1105))

## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: docs

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] It's submitted to the `next` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
