### PR TITLE
feat: add  method to get validation model  and it children deeply

### DIFF
--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -224,9 +224,9 @@ function collectNestedValidationResults (validations, nestedState, path, results
 
 /**
  *  Returns a deep object containing the values of the provided model and its child and nested results.
- * @param {Object} iModel - The model to retrieve the values from.
- * @param {Object} iChildResults - The child results of the model.
- * @param {Object} iNestedResults - The nested results of the model.
+ * @param {Object} iModel - Internal $model to retrieve the $model for each layer interaction.
+ * @param {Object} iChildResults - Internal ChildResults from current layer interaction.
+ * @param {Object} iNestedResults - Internal NestedResults from current layer interaction.
  * @returns {Object} - A deep object containing the values of the model and its child and nested results.
  */
 function getValuesDeep(model, childResults, nestedResults) {


### PR DESCRIPTION
## Summary

I use to use this library on my vue applications, but i aways fell its missing a method to get all the `$model` values from all validations and nested children included so i decided to implement it by myself.

## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] It's submitted to the `next` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup (its not passing even without my changes)
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
