### PR TITLE
Add types reference to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "jest": "^27.0.6",
     "jest-serializer-vue": "^2.0.2",
     "lerna": "^4.0.0",
+    "rollup-plugin-copy": "^3.4.0",
     "standard-version": "^9.3.1",
     "rollup": "^3.19.1",
     "vue": "^3.2.2",

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.2",
   "description": "Validators for Vuelidate",
   "main": "dist/index.cjs",
-  "types": "index.d.ts",
+  "types": "dist/index.d.cts",
   "module": "dist/index.mjs",
   "unpkg": "dist/index.iife.min.js",
   "jsdelivr": "dist/index.iife.min.js",
@@ -41,7 +41,6 @@
     "access": "public"
   },
   "files": [
-    "dist",
-    "index.d.ts"
+    "dist"
   ]
 }

--- a/packages/validators/package.json
+++ b/packages/validators/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.2",
   "description": "Validators for Vuelidate",
   "main": "dist/index.cjs",
-  "types": "dist/index.d.cts",
+  "types": "index.d.ts",
   "module": "dist/index.mjs",
   "unpkg": "dist/index.iife.min.js",
   "jsdelivr": "dist/index.iife.min.js",
@@ -13,6 +13,23 @@
     "directory": "packages/validators"
   },
   "license": "MIT",
+  "files": [
+    "dist",
+    "index.d.ts"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./*": "./*"
+  },
   "scripts": {
     "build": "rollup -c rollup.config.mjs",
     "dev": "yarn build --watch",
@@ -39,8 +56,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "files": [
-    "dist"
-  ]
+  }
 }

--- a/packages/validators/rollup.config.mjs
+++ b/packages/validators/rollup.config.mjs
@@ -3,7 +3,8 @@ import { generateConfigFactory, generateOutputConfig } from '../../rollup.base.m
 export default [
   generateConfigFactory({
     libraryName: 'VuelidateValidators',
-    outputConfigs: generateOutputConfig('index')
+    outputConfigs: generateOutputConfig('index'),
+    copyTypes: true
   }),
   generateConfigFactory({
     libraryName: 'VuelidateValidators',

--- a/packages/vuelidate/package.json
+++ b/packages/vuelidate/package.json
@@ -3,7 +3,7 @@
   "description": "Simple, lightweight model-based validation for Vue.js",
   "version": "2.0.2",
   "main": "dist/index.cjs",
-  "types": "dist/index.d.cts",
+  "types": "index.d.ts",
   "module": "dist/index.mjs",
   "unpkg": "dist/index.iife.min.js",
   "jsdelivr": "dist/index.iife.min.js",
@@ -14,12 +14,19 @@
   },
   "license": "MIT",
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./*": "./*"
   },

--- a/packages/vuelidate/package.json
+++ b/packages/vuelidate/package.json
@@ -19,6 +19,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },

--- a/packages/vuelidate/package.json
+++ b/packages/vuelidate/package.json
@@ -3,7 +3,7 @@
   "description": "Simple, lightweight model-based validation for Vue.js",
   "version": "2.0.2",
   "main": "dist/index.cjs",
-  "types": "index.d.ts",
+  "types": "dist/index.d.cts",
   "module": "dist/index.mjs",
   "unpkg": "dist/index.iife.min.js",
   "jsdelivr": "dist/index.iife.min.js",
@@ -14,12 +14,10 @@
   },
   "license": "MIT",
   "files": [
-    "dist",
-    "index.d.ts"
+    "dist"
   ],
   "exports": {
     ".": {
-      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },

--- a/packages/vuelidate/rollup.config.mjs
+++ b/packages/vuelidate/rollup.config.mjs
@@ -2,5 +2,6 @@ import { generateConfigFactory, generateOutputConfig } from '../../rollup.base.m
 
 export default generateConfigFactory({
   libraryName: 'Vuelidate',
-  outputConfigs: generateOutputConfig('index')
+  outputConfigs: generateOutputConfig('index'),
+  copyTypes: true
 })

--- a/rollup.base.mjs
+++ b/rollup.base.mjs
@@ -2,6 +2,7 @@ import terser from '@rollup/plugin-terser'
 import resolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import { babel } from '@rollup/plugin-babel'
+import copy from 'rollup-plugin-copy'
 
 export function generateOutputConfig (fileName = 'index', opts) {
   return {
@@ -23,7 +24,12 @@ export function generateOutputConfig (fileName = 'index', opts) {
   }
 }
 
-function generateConfigFactory ({ libraryName, input = 'src/index.js', outputConfigs }) {
+function generateConfigFactory({
+  libraryName,
+  input = 'src/index.js',
+  outputConfigs,
+  copyTypes = false
+}) {
   /**
    * @type {import('rollup').RollupOptions}
    */
@@ -56,6 +62,26 @@ function generateConfigFactory ({ libraryName, input = 'src/index.js', outputCon
     if (isMinified) {
       opts.plugins.push(
         terser()
+      )
+    }
+    if (copyTypes) {
+      opts.plugins.push(
+        copy({
+          hook: 'writeBundle',
+          flatten: true,
+          targets: [
+            {
+              src: 'index.d.ts',
+              dest: 'dist',
+              rename: 'index.d.cts'
+            },
+            {
+              src: 'index.d.ts',
+              dest: 'dist',
+              rename: 'index.d.mts'
+            }
+          ]
+        })
       )
     }
     return opts

--- a/yarn.lock
+++ b/yarn.lock
@@ -2601,6 +2601,21 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
   integrity sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
 
+"@types/fs-extra@^8.0.1":
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.2.tgz#7125cc2e4bdd9bd2fc83005ffdb1d0ba00cca61f"
+  integrity sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/glob@^7.1.1":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -2636,6 +2651,11 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/minimatch@*":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/minimatch@^3.0.3":
   version "3.0.5"
@@ -3704,6 +3724,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+colorette@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
+  integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
 
 columnify@^1.5.4:
   version "1.5.4"
@@ -4975,6 +5000,17 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-glob@^3.0.3:
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-glob@^3.1.1, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
@@ -5161,7 +5197,7 @@ fs-access@^1.0.1:
   dependencies:
     null-check "^1.0.0"
 
-fs-extra@8.1.0:
+fs-extra@8.1.0, fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
@@ -5442,6 +5478,20 @@ globals@^13.6.0, globals@^13.9.0:
   integrity sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==
   dependencies:
     type-fest "^0.20.2"
+
+globby@10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.1.tgz#4782c34cb75dd683351335c5829cc3420e606b22"
+  integrity sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.0.3"
+    glob "^7.1.3"
+    ignore "^5.1.1"
+    merge2 "^1.2.3"
+    slash "^3.0.0"
 
 globby@^11.0.2:
   version "11.0.2"
@@ -6048,6 +6098,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-plain-object@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-3.0.1.tgz#662d92d24c0aa4302407b0d45d21f2251c85f85b"
+  integrity sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==
 
 is-plain-object@^5.0.0:
   version "5.0.0"
@@ -7134,7 +7189,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.3.0, merge2@^1.4.1:
+merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -8569,6 +8624,17 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rollup-plugin-copy@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-copy/-/rollup-plugin-copy-3.4.0.tgz#f1228a3ffb66ffad8606e2f3fb7ff23141ed3286"
+  integrity sha512-rGUmYYsYsceRJRqLVlE9FivJMxJ7X6jDlP79fmFkL8sJs7VVMSVyA2yfyL+PGyO/vJs4A87hwhgVfz61njI+uQ==
+  dependencies:
+    "@types/fs-extra" "^8.0.1"
+    colorette "^1.1.0"
+    fs-extra "^8.1.0"
+    globby "10.0.1"
+    is-plain-object "^3.0.0"
 
 rollup@^2.59.0:
   version "2.64.0"


### PR DESCRIPTION
## Summary

With TS 5.0 introducing "bundler" module resolution (may also apply to "Node16" and "NodeNext", although I haven't tested), importing types from `@vuelidate/core` will result in TS complaining that it can't resolve type declarations. TS seems to find the type declaration file but won't use it because it's not explicitly listed under "exports" in `package.json`.

See this issue for more details: https://github.com/microsoft/TypeScript/issues/52363

This PR just adds a "types" export line to the `package.json`, which seems to keep TS happy and resolve the error.

## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] It's submitted to the `next` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
N/A
