### PR TITLE
docs(readme): correct $error equivalence

### DIFF
--- a/packages/docs/src/api/state.md
+++ b/packages/docs/src/api/state.md
@@ -41,7 +41,7 @@ The presence of those special reserved keywords means that you cannot specify yo
 * **Type:** `Boolean`
 * **Details:**
 
-  Convenience flag to easily decide if a message should be displayed. Equivalent to `this.$dirty && !this.$pending && this.$invalid`.
+  Convenience flag to easily decide if a message should be displayed. Equivalent to `this.$dirty && (this.$pending || this.$invalid)`.
 
 ## $errors
 


### PR DESCRIPTION
## Summary

As https://github.com/vuelidate/vuelidate/issues/1046 suggests, `$error` is true when the form is `$dirty` and either `$pending` or `$invalid`.

## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Documentation

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] It's submitted to the `next` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included