### PR TITLE
Revert type changes from #1088

### DIFF
--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -115,9 +115,6 @@ export type BaseValidation <
   readonly $reset: () => void
   readonly $commit: () => void
   readonly $validate: () => Promise<boolean>
-
-  // For accessing individual form properties on v$
-  readonly [key: string]: any
 };
 
 export type NestedValidations <Vargs extends ValidationArgs = ValidationArgs, T = unknown> = {


### PR DESCRIPTION
This reverts commit 9545160289017c60a62d6b3017f9f0500040a4a0.

## Summary

In #1088 a generic key, `any` combination was added to `BaseValidation`. This allows one to use arbitrary possibly incorrect accessing of properties on `v$` (say `v$.somethingThatDoesNotExist`) without TypeScript errors, given that TypeScript infers `any` and basically stops checking. Therefore I think the introduced change degrades the quality of the types in this package.

The issue as presented in #1088 seems to be caused not by an incorrect typing in the type declarations, but rather by a missing generic argument, as seems to be implied by the listed `Validation<ValidationArgs<unknown>, unknown>` type description. If one ensures that in the scope of e.g. `useVuelidate` the generic `T` for the `state` argument is properly detected, actual values should be properly accessible on the resulting object.

## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes (theoretically for people relying on the new broken behavior; limited to TypeScript failure as there are no runtime changes)
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] It's submitted to the `next` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
