### PR TITLE
fix: clear applied $externalResults on $model change when rules recompute

### DIFF
--- a/packages/vuelidate/src/core.js
+++ b/packages/vuelidate/src/core.js
@@ -466,7 +466,8 @@ export function setValidations ({
         const s = unwrap(state)
         const external = unwrap(externalResults)
         if (external) {
-          external[key] = cachedExternalResults[key]
+          // delete external[key] breaks vue:2 specs
+          external[key] = undefined
         }
         if (isRef(s[key])) {
           s[key].value = val


### PR DESCRIPTION
## Summary

If you're using dynamic rules object via computed as documented, your client-side validations work dynamically as expected. If you add $externalResults to the mix and the rules rules are re-computed after $externalErrors been applied, $ externalErrors are no longer cleared when $model changes.

fixes #1232 

## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] It's submitted to the `next` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

