### PR TITLE
docs: Fix link for validation configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ export default {
 
 You can provide global configs to your Vuelidate instance using the third parameter of `useVuelidate` or by using the `validationsConfig`. These
 config options are used to change some core Vuelidate functionality, like `$autoDirty`, `$lazy`, `$scope` and more. Learn all about them
-in [Validation Configuration](https://vuelidate-next.netlify.app/api.html#validation-configuration).
+in [Validation Configuration](https://vuelidate-next.netlify.app/api/configuration.html).
 
 ### Config with Options API
 


### PR DESCRIPTION
## Summary

Fix broken/outdated link for validation configuration docs on "Providing global config to your Vuelidate instance" section.

## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe:
- Fix broken link for validation configuration docs

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [X] It's submitted to the `next` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
