### PR TITLE
fix #1121 Using $validationGroups results in Typescript Error (TS2345)

### DIFF
--- a/packages/vuelidate/index.d.ts
+++ b/packages/vuelidate/index.d.ts
@@ -187,7 +187,7 @@ export function useVuelidate<
   EState extends ExtractState<Vargs> = ExtractState<Vargs>
 >(
   validationsArgs: Ref<Vargs> | Vargs,
-  state: T | Ref<T> | ToRefs<T>,
+  state: Omit<T,'$validationGroups'> | Ref<Omit<T,'$validationGroups'>> | ToRefs<Omit<T,'$validationGroups'>>,
   globalConfig?: GlobalConfig
 ): Ref<Validation<Vargs, T>>;
 


### PR DESCRIPTION
Added Omit to state in the useVuelidate function to emit the $validationGroups property

## Summary

Adds Omit to the useVuelidate state type to omits the $validationGroups key

fixes #1121

## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] It's submitted to the `next` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included
