### PR TITLE
fix: $rewardEarly implementation

### DIFF
--- a/packages/test-project/src/App.vue
+++ b/packages/test-project/src/App.vue
@@ -2,15 +2,56 @@
   <div id="app">
     <div class="navigation">
       <ul>
-        <li><router-link to="/">Simple Form</router-link></li>
-        <li><router-link to="/async-simple">Async Form</router-link></li>
-        <li><router-link to="/i18n-simple">i18n Simple Form</router-link></li>
-        <li><router-link to="/old-api">Old api</router-link></li>
-        <li><router-link to="/nested-validations">Nested Validations</router-link></li>
-        <li><router-link to="/nested-ref">Nested Ref</router-link></li>
-        <li><router-link to="/collection-validations">Collection Validations</router-link></li>
-        <li><router-link to="/external-validations">External Validations</router-link></li>
-        <li><router-link to="/nested-validations-with-scopes">Nested Validations with Scopes</router-link></li>
+        <li>
+          <router-link to="/">
+            Simple Form
+          </router-link>
+        </li>
+        <li>
+          <router-link to="/async-simple">
+            Async Form
+          </router-link>
+        </li>
+        <li>
+          <router-link to="/i18n-simple">
+            i18n Simple Form
+          </router-link>
+        </li>
+        <li>
+          <router-link to="/old-api">
+            Old api
+          </router-link>
+        </li>
+        <li>
+          <router-link to="/nested-validations">
+            Nested Validations
+          </router-link>
+        </li>
+        <li>
+          <router-link to="/nested-ref">
+            Nested Ref
+          </router-link>
+        </li>
+        <li>
+          <router-link to="/collection-validations">
+            Collection Validations
+          </router-link>
+        </li>
+        <li>
+          <router-link to="/external-validations">
+            External Validations
+          </router-link>
+        </li>
+        <li>
+          <router-link to="/nested-validations-with-scopes">
+            Nested Validations with Scopes
+          </router-link>
+        </li>
+        <li>
+          <router-link to="/reward-early">
+            $rewardEarly
+          </router-link>
+        </li>
       </ul>
     </div>
     <router-view />

--- a/packages/test-project/src/components/RewardEarly.vue
+++ b/packages/test-project/src/components/RewardEarly.vue
@@ -1,0 +1,144 @@
+
+<script setup>
+import { useVuelidate } from '@vuelidate/core'
+import { required, email, minLength, helpers } from '@vuelidate/validators'
+import { reactive, computed, version } from 'vue'
+
+function Contact () {
+  return {
+    id: Date.now(),
+    name: '',
+    email: ''
+  }
+}
+
+const asyncName = helpers.withAsync({
+  $validator: (value) => {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        if (value === 'renato') {
+          resolve({ $valid: true })
+        } else {
+          resolve({ $valid: false })
+        }
+      }, 100)
+    })
+  },
+  $message: 'Name must be renato'
+})
+
+const contactValidationSchema = {
+  name: { required, minLength: minLength(3) },
+  email: { email }
+}
+
+const defaultContact = new Contact()
+const state = reactive({
+  name: '',
+  address: '',
+  contacts: {
+    [defaultContact.id]: defaultContact
+  }
+})
+
+function addContact () {
+  const newContact = new Contact()
+  state.contacts[newContact.id] = newContact
+}
+
+function removeContact (id) {
+  delete state.contacts[id]
+}
+
+const rules = computed(() => ({
+  name: { required, m: minLength(3), asyncName },
+  address: { required },
+  contacts: Object.keys(state.contacts).reduce((acc, key) => {
+    acc[key] = contactValidationSchema
+    return acc
+  }, {})
+}))
+
+const v$ = useVuelidate(rules, state, { $rewardEarly: true })
+</script>
+
+<template>
+  <div>
+    <div class="field">
+      <label>
+        Name
+        <input
+          v-model="v$.name.$model"
+          @blur="v$.name.$commit"
+        >
+      </label>
+      <p
+        v-for="error of v$.name.$errors"
+        :key="error.$uid"
+      >
+        {{ error.$message }}
+      </p>
+    </div>
+
+    <div class="field">
+      <label>
+        Address
+        <input
+          v-model="v$.address.$model"
+          @blur="v$.address.$commit"
+        >
+      </label>
+      <p
+        v-for="error of v$.address.$errors"
+        :key="error.$uid"
+      >
+        {{ error.$message }}
+      </p>
+    </div>
+
+    <fieldset
+      v-for="(contact, id) in v$.contacts.$model"
+      :key="id"
+    >
+      <legend>Contact {{ id }}</legend>
+      <div>
+        <label>
+          name
+          <input
+            v-model="v$.contacts[id].name.$model"
+            @blur="v$.contacts[id].name.$commit"
+          >
+        </label>
+        <p
+          v-for="error of v$.contacts[id].name.$errors"
+          :key="error.$uid"
+        >
+          {{ error.$message }}
+        </p>
+      </div>
+      <div>
+        <label>
+          email
+          <input
+            v-model="v$.contacts[id].email.$model"
+            @blur="v$.contacts[id].email.$commit"
+          >
+        </label>
+        <p
+          v-for="error of v$.contacts[id].email.$errors"
+          :key="error.$uid"
+        >
+          {{ error.$message }}
+        </p>
+      </div>
+      <button @click="removeContact(id)">
+        X
+      </button>
+    </fieldset>
+    <button @click="addContact">
+      Add contact
+    </button>
+
+    <pre><code>{{ { vue: version, $silentErrors: v$.$silentErrors, $silentInvalids: v$.$silentInvalids } }}</code></pre>
+  </div>
+</template>

--- a/packages/test-project/src/routes.js
+++ b/packages/test-project/src/routes.js
@@ -7,6 +7,7 @@ import I18nSimpleForm from './components/I18nSimpleForm.vue'
 import ExternalValidationsForm from './components/ExternalValidationsForm.vue'
 import AsyncValidators from './components/AsyncValidators.vue'
 import NestedValidationsWithScopes from './components/NestedValidationsWithScopes/ParentValidator.vue'
+import RewardEarly from './components/RewardEarly.vue'
 
 export const routes = [
   {
@@ -44,5 +45,9 @@ export const routes = [
   {
     path: '/nested-validations-with-scopes',
     component: NestedValidationsWithScopes
+  },
+  {
+    path: '/reward-early',
+    component: RewardEarly
   }
 ]


### PR DESCRIPTION
## Summary

1. Moved `$lastInvalid` sync assignment from the `results.$invalid` computed
  because computed props should be side-effect free.
2. Added `$lastCommittedOn` as a watch source because `3.4.x` vue will cache
  computed more aggressively and `$lastInvalidState` would be out of sync
  in the "commit() called when model valid" scenario:
   1. `$commit()` sets `$lastInvalidState` to `true`
   1. validators run and return invalid as `false`
   1. `result.$invalid` computed is already `false` (initial), so it will not recompute (cached)
   1. the `watcher` will not be triggered because `$result.$invalid` dep did not change.
   1. last `$invalidState` is not sync to false — to match `result.$invalid`, and thus `$model` change triggers validators to run immediately.
3. flush "post" is required for async validators to work in this mode, otherwise
  last invalid state will be flipped to false since sync validators run first
  and turn invalid to false "before" pending is set to true and it will prevent
  them from running (Guessing). At least is required for 3.4.x and that's
  the version the majority should be using.
  
I don't know if it's out-of-scope of this PR to update vue, but 3.4.x
brought many changes to computed optimization which vuelidate relies on
heavily and it's the future.


fixes #1237

## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] It's submitted to the `next` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included
