### PR TITLE
docs: added list of possible alternatives in readme and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Vuelidate is currently in LTS mode, so you may want to look at similar form libr
 
 ### Model-based validation
 
-- **Regle**: ✅ Headless form validation library for Vue.js [[Github](https://github.com/victorgarciaesgi/regle), [Docs](https://reglejs.dev/)]
+- **Regle**: ✅ Headless form validation library for Vue.js [[Github](https://github.com/victorgarciaesgi/regle), [Docs](https://reglejs.dev/), [Migration guide](https://reglejs.dev/introduction/migrate-from-vuelidate)]
   - A validation library that use a similar API as Vuelidate's, with improved Typescript support, Nuxt integration and schema libraries (Zod, Valibot, Arktype)
 
 ### Composable approach

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ npm install @vuelidate/core @vuelidate/validators
 yarn add @vuelidate/core @vuelidate/validators
 ```
 
+## Possible alternatives
+
+Vuelidate is currently in LTS mode, so you may want to look at similar form libraries that are currently actively maintained.
+
+### Model-based validation
+
+- **Regle**: ✅ Headless form validation library for Vue.js [[Github](https://github.com/victorgarciaesgi/regle), [Docs](https://reglejs.dev/)]
+  - A validation library that use a similar API as Vuelidate's, with improved Typescript support, Nuxt integration and schema libraries (Zod, Valibot, Arktype)
+
+### Composable approach
+
+- **Vee-Validate**: Painless Vue forms [[Github](https://github.com/logaretm/vee-validate/), [Docs](https://vee-validate.logaretm.com/v4/)]
+
+### UI based
+
+- **VueForm**: Open-Source Form Framework for Vue [[Github](https://github.com/vueform/vueform), [Docs](https://vueform.com/)]
+
 ## Usage with Options API
 
 To use Vuelidate with the Options API, you just need to return an empty Vuelidate instance from `setup`.

--- a/packages/docs/src/index.md
+++ b/packages/docs/src/index.md
@@ -42,6 +42,23 @@ Add these imports to your browser:
 
 Now you can access use `VueDemi`, `Vuelidate` and `VuelidateValidators` to build validations.
 
+## Possible alternatives
+
+Vuelidate is currently in LTS mode, so you may want to look at similar form libraries that are currently actively maintained.
+
+### Model-based validation
+
+- **Regle**: ✅ Headless form validation library for Vue.js [[Github](https://github.com/victorgarciaesgi/regle), [Docs](https://reglejs.dev/)]
+  - A validation library that use a similar API as Vuelidate's, with improved Typescript support, Nuxt integration and schema libraries (Zod, Valibot, Arktype)
+
+### Composable approach
+
+- **Vee-Validate**: Painless Vue forms [[Github](https://github.com/logaretm/vee-validate/), [Docs](https://vee-validate.logaretm.com/v4/)]
+
+### UI based
+
+- **VueForm**: Open-Source Form Framework for Vue [[Github](https://github.com/vueform/vueform), [Docs](https://vueform.com/)]
+
 ## Getting Started
 
 ::: tip

--- a/packages/docs/src/index.md
+++ b/packages/docs/src/index.md
@@ -48,7 +48,7 @@ Vuelidate is currently in LTS mode, so you may want to look at similar form libr
 
 ### Model-based validation
 
-- **Regle**: ✅ Headless form validation library for Vue.js [[Github](https://github.com/victorgarciaesgi/regle), [Docs](https://reglejs.dev/)]
+- **Regle**: ✅ Headless form validation library for Vue.js [[Github](https://github.com/victorgarciaesgi/regle), [Docs](https://reglejs.dev/), [Migration guide](https://reglejs.dev/introduction/migrate-from-vuelidate)]
   - A validation library that use a similar API as Vuelidate's, with improved Typescript support, Nuxt integration and schema libraries (Zod, Valibot, Arktype)
 
 ### Composable approach


### PR DESCRIPTION
## Summary

Fellowing a discussion with Damian, where he suggested I add a list of possible alternatives to guide users into actively maintained form libraries.

Feel free to tell me if the description feet you. I also added 2 more popular libraries and splited the list into categories, with Regle being the closest alternative to Vuelidate's behaviour.

## Metadata

**What kind of change does this PR introduce?** (check at least one)

- [x] Docs

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] I have read the [Contribution Guides](https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines)
- [x] It's submitted to the `next` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [x] New/updated tests are included

